### PR TITLE
Fix weird compilation errors

### DIFF
--- a/tested/judge/compilation.py
+++ b/tested/judge/compilation.py
@@ -109,13 +109,13 @@ def process_compile_results(
         shown_messages = True
 
     # Report errors if needed.
+    if results.timeout:
+        return messages, Status.TIME_LIMIT_EXCEEDED, annotations
+    if results.memory:
+        return messages, Status.MEMORY_LIMIT_EXCEEDED, annotations
     if results.exit != 0:
         if not shown_messages:
             messages.append(f"Exitcode {results.exit}.")
-        if results.timeout:
-            return messages, Status.TIME_LIMIT_EXCEEDED, annotations
-        if results.memory:
-            return messages, Status.MEMORY_LIMIT_EXCEEDED, annotations
         return messages, Status.COMPILATION_ERROR, annotations
     else:
         return messages, Status.CORRECT, annotations

--- a/tested/manual.py
+++ b/tested/manual.py
@@ -24,7 +24,7 @@ def read_config() -> DodonaConfig:
         "resources":            Path('exercise/echo/evaluation'),
         "source":               Path('exercise/echo/solution/run-error.c'),
         "judge":                Path('.'),
-        "workdir":              Path('../workdir'),
+        "workdir":              Path('workdir'),
         "plan_name":            "two.tson",
         "options":              {
             "parallel": True,


### PR DESCRIPTION
A weird Haskell error still occurs (https://dodona.ugent.be/en/submissions/5952347/). Some investigating reveals:

- When a compilation error occurs in batch mode, Tested switches to individual compilation by default.
- When each context is being compiled in Haskell, this is very slow.
- Tested has a global timeout, which will be triggered in the individual mode with Haskell.
- This means that sometimes the compilation process is killed due to a timeout.
- When the compilation process is killed, the exit code is still 0.
- The code only checked for timeout errors if the compilation exit code was not 0.

(This might also be the cause of #68, perhaps we should try to revert parts of #70 later (since it will now hide unexpected errors).)

