### PR TITLE
Fix wrong JSON encoding unknown type Kotlin and Java

### DIFF
--- a/tested/languages/java/templates/Values.java
+++ b/tested/languages/java/templates/Values.java
@@ -87,7 +87,7 @@ public class Values {
             data = "{" + String.join(", ", elements) + "}";
         } else {
             type = "unknown";
-            data = value.toString();
+            data = "\"" + escape(value.toString()) + "\"";
         }
         return List.of(type, data);
     }

--- a/tested/languages/kotlin/templates/Values.kt
+++ b/tested/languages/kotlin/templates/Values.kt
@@ -100,7 +100,7 @@ private fun internalEncode(value: Any?): Array<String> {
                 .joinToString(separator = ", ", prefix = "{", postfix = "}")
     } else {
         type = "unknown"
-        data = value.toString()
+        data = String.format("\"%s\"", escape(value.toString()));
     }
 
     return arrayOf(type, data)


### PR DESCRIPTION
Example fault:
```json
{
  "type": "unknown",
  "data": kotlin.Unit
}
```
Fix:
```json
{
  "type": "unknown",
  "data": "kotlin.Unit"
}
```
