### PR TITLE
First fixes for not executed testcases

### DIFF
--- a/tested/dodona.py
+++ b/tested/dodona.py
@@ -54,6 +54,7 @@ class Status(str, Enum):
     WRONG = "wrong"
     INTERNAL_ERROR = "internal error"
     OUTPUT_LIMIT_EXCEEDED = "output limit exceeded"
+    NOT_EXECUTED = "wrong"
 
 
 @dataclass

--- a/tested/dodona.py
+++ b/tested/dodona.py
@@ -54,6 +54,8 @@ class Status(str, Enum):
     WRONG = "wrong"
     INTERNAL_ERROR = "internal error"
     OUTPUT_LIMIT_EXCEEDED = "output limit exceeded"
+    # Dodona issue NOT PROCESSED STATE:
+    # https://github.com/dodona-edu/dodona/issues/1785
     NOT_EXECUTED = "wrong"
 
 

--- a/tested/judge/evaluation.py
+++ b/tested/judge/evaluation.py
@@ -413,7 +413,7 @@ def _add_channel(bundle: Bundle, output: OutputChannel, channel: Channel,
         updates.append(CloseTest(
             generated="",
             status=StatusMessage(
-                enum=Status.WRONG,
+                enum=Status.NOT_EXECUTED,
                 human="Test niet uitgevoerd."
             ),
             accepted=False
@@ -433,8 +433,11 @@ def prepare_evaluation(bundle: Bundle, collector: OutputManager):
     for i, tab in enumerate(bundle.plan.tabs):
         collector.prepare_tab(StartTab(title=tab.name), i)
         for j, context in enumerate(tab.contexts):
+            description = context.description if context.description else \
+                "Context niet uitgevoerd."
+
             collector.prepare_context(
-                StartContext(description=context.description), i, j
+                StartContext(description=description), i, j
             )
 
             # Start with the context testcase.
@@ -455,7 +458,8 @@ def prepare_evaluation(bundle: Bundle, collector: OutputManager):
             if not context.testcases:
                 _add_channel(bundle, exit_output, Channel.EXIT, updates)
 
-            updates.append(AppendMessage("Testgeval niet uitgevoerd."))
+            if context.description:
+                updates.append(AppendMessage("Context niet uitgevoerd."))
             updates.append(CloseTestcase(accepted=False))
 
             # Begin normal testcases.
@@ -476,7 +480,6 @@ def prepare_evaluation(bundle: Bundle, collector: OutputManager):
                 if t == len(context.testcases):
                     _add_channel(bundle, exit_output, Channel.EXIT, updates)
 
-                updates.append(AppendMessage("Testgeval niet uitgevoerd."))
                 updates.append(CloseTestcase(accepted=False))
 
             collector.prepare_context(updates, i, j)

--- a/tested/judge/evaluation.py
+++ b/tested/judge/evaluation.py
@@ -433,8 +433,7 @@ def prepare_evaluation(bundle: Bundle, collector: OutputManager):
     for i, tab in enumerate(bundle.plan.tabs):
         collector.prepare_tab(StartTab(title=tab.name), i)
         for j, context in enumerate(tab.contexts):
-            description = context.description if context.description else \
-                "Context niet uitgevoerd."
+            description = context.description or "Context niet uitgevoerd."
 
             collector.prepare_context(
                 StartContext(description=description), i, j


### PR DESCRIPTION
Some fixes for not executed testcases, see #114.
- Only message at context level.
- When context has no description, use message as description.

![dodona localhost_3000_nl_submissions_2348_](https://user-images.githubusercontent.com/38499296/101476720-79492080-394e-11eb-89c3-5683fbf56e52.png)

Add pseudo status `NOT_EXECUTED` is currently equal to the status `wrong` at Dodona.