### PR TITLE
Namespaces

### DIFF
--- a/exercise/isbn/evaluation/one-with-crashing-assignment-java.tson
+++ b/exercise/isbn/evaluation/one-with-crashing-assignment-java.tson
@@ -17,7 +17,7 @@
                     "type": "sequence",
                     "variable": "codes01",
                     "expression": {
-                      "type": "namespace",
+                      "type": "function",
                       "namespace": "ex",
                       "name": "get",
                       "arguments": []

--- a/exercise/isbn/evaluation/one-with-crashing-assignment-kotlin.tson
+++ b/exercise/isbn/evaluation/one-with-crashing-assignment-kotlin.tson
@@ -17,7 +17,7 @@
                     "type": "sequence",
                     "variable": "codes01",
                     "expression": {
-                      "type": "namespace",
+                      "type": "function",
                       "namespace": "ex",
                       "name": "invoke",
                       "arguments": []

--- a/exercise/objects/evaluation/plan.tson
+++ b/exercise/objects/evaluation/plan.tson
@@ -28,7 +28,7 @@
                 },
                 {
                   "input": {
-                    "type": "namespace",
+                    "type": "function",
                     "namespace": "instance",
                     "name": "check",
                     "arguments": [
@@ -49,7 +49,7 @@
                 },
                 {
                   "input": {
-                    "type": "namespace",
+                    "type": "function",
                     "namespace": "instance",
                     "name": "check",
                     "arguments": [

--- a/tested/languages/haskell/templates/function.mako
+++ b/tested/languages/haskell/templates/function.mako
@@ -1,7 +1,7 @@
 ## This generates a function expression in Haskell.
 <%! from tested.serialisation import FunctionType %>\
 <%page args="function" />\
-% if function.type == FunctionType.NAMESPACE or (function.type == FunctionType.FUNCTION and function.namespace):
+% if function.namespace:
     ${function.namespace}.\
 % endif
 ${function.name} \

--- a/tested/languages/java/templates/function.mako
+++ b/tested/languages/java/templates/function.mako
@@ -4,7 +4,7 @@
 % if function.type == FunctionType.CONSTRUCTOR:
     new \
 % endif
-% if function.type == FunctionType.NAMESPACE or (function.type == FunctionType.FUNCTION and function.namespace):
+% if function.namespace and not (function.has_root_namespace and function.type == FunctionType.CONSTRUCTOR):
     ${function.namespace}.\
 % endif
 ${function.name}\

--- a/tested/languages/javascript/templates/function.mako
+++ b/tested/languages/javascript/templates/function.mako
@@ -5,8 +5,7 @@ await \
 % if function.type == FunctionType.CONSTRUCTOR:
     new \
 % endif
-% if function.type == FunctionType.NAMESPACE or (function.type in (FunctionType.FUNCTION, FunctionType.CONSTRUCTOR) \
-                                                     and function.namespace):
+% if function.namespace:
     ${function.namespace}.\
 % endif
 ${function.name}\

--- a/tested/languages/kotlin/templates/function.mako
+++ b/tested/languages/kotlin/templates/function.mako
@@ -2,7 +2,7 @@
 <%! from tested.serialisation import FunctionType, NamedArgument, Expression %>\
 <%! from tested.utils import get_args %>\
 <%page args="function" />\
-% if function.type == FunctionType.NAMESPACE:
+% if (not function.has_root_namespace or function.type == FunctionType.NAMESPACE):
     ${function.namespace}!!.\
 % endif
 ${function.name}\

--- a/tested/languages/kotlin/templates/function.mako
+++ b/tested/languages/kotlin/templates/function.mako
@@ -2,7 +2,7 @@
 <%! from tested.serialisation import FunctionType, NamedArgument, Expression %>\
 <%! from tested.utils import get_args %>\
 <%page args="function" />\
-% if (not function.has_root_namespace or function.type == FunctionType.NAMESPACE):
+% if not function.has_root_namespace and function.namespace:
     ${function.namespace}!!.\
 % endif
 ${function.name}\

--- a/tested/languages/python/templates/function.mako
+++ b/tested/languages/python/templates/function.mako
@@ -2,7 +2,7 @@
 <%! from tested.serialisation import FunctionType, NamedArgument, Expression %>\
 <%! from tested.utils import get_args %>\
 <%page args="function" />\
-% if (not function.has_root_namespace or function.type == FunctionType.NAMESPACE):
+% if not function.has_root_namespace and function.namespace:
     ${function.namespace}.\
 % endif
 ${function.name}\

--- a/tested/languages/python/templates/function.mako
+++ b/tested/languages/python/templates/function.mako
@@ -2,7 +2,7 @@
 <%! from tested.serialisation import FunctionType, NamedArgument, Expression %>\
 <%! from tested.utils import get_args %>\
 <%page args="function" />\
-% if function.type == FunctionType.NAMESPACE:
+% if (not function.has_root_namespace or function.type == FunctionType.NAMESPACE):
     ${function.namespace}.\
 % endif
 ${function.name}\

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -187,10 +187,10 @@ class Identifier(str, WithFeatures, WithFunctions):
 class FunctionType(str, Enum):
     FUNCTION = "function"
     """
-    A function expression. A function can be in a namespace if it is provide.
+    A function expression. A function can be in a namespace if it is provided.
     The namespace can be an instance, in which case it is a method (e.g. Java or
     Python), but it can also be a function inside a module (e.g. Haskell).
-    For e.g. Java: a function without given namespace will have the namespace of
+    E.g. with Java: a function without a given namespace will have the namespace of
     it's implementing class
     """
     CONSTRUCTOR = "constructor"

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -187,14 +187,11 @@ class Identifier(str, WithFeatures, WithFunctions):
 class FunctionType(str, Enum):
     FUNCTION = "function"
     """
-    A top-level function expression. In some configs, this might be translated to a
-    NAMESPACE function (e.g. in Java, this is translated to a static method).
-    """
-    NAMESPACE = "namespace"
-    """
-    A function in a namespace. The namespace can be an instance, in which case it
-    is a method (e.g. Java or Python), but it can also be a function inside a module
-    (e.g. Haskell).
+    A function expression. A function can be in a namespace if it is provide.
+    The namespace can be an instance, in which case it is a method (e.g. Java or
+    Python), but it can also be a function inside a module (e.g. Haskell).
+    For e.g. Java: a function without given namespace will have the namespace of
+    it's implementing class
     """
     CONSTRUCTOR = "constructor"
     """
@@ -237,8 +234,6 @@ class FunctionCall(WithFeatures, WithFunctions):
     def namespace_requirements(cls, values):
         type_ = values.get("type")
         namespace_ = values.get("namespace")
-        if type_ == FunctionType.NAMESPACE and not namespace_:
-            raise ValueError("Namespace functions must have a namespace.")
         if type_ == FunctionType.PROPERTY and not namespace_:
             raise ValueError("Property functions must have a namespace.")
         return values


### PR DESCRIPTION
Remove `NAMESPACE` function call type, because it can be repressented by the `FUNCTION` type and a given namespace, which is more intuitive.

close #144