### PR TITLE
Fix escape string DSL

### DIFF
--- a/tested/dsl/statement.py
+++ b/tested/dsl/statement.py
@@ -138,7 +138,7 @@ class Parser:
                               data=float(token.value))
         elif token.type == 'ESCAPED_STRING':
             return StringType(type=BasicStringTypes.TEXT,
-                              data=literal_eval(token.value))
+                              data=token.value[1:-1])
         elif token.type == 'TRUE':
             return BooleanType(type=BasicBooleanTypes.BOOLEAN, data=True)
         elif token.type == 'FALSE':

--- a/tested/languages/python/templates/value_basic.mako
+++ b/tested/languages/python/templates/value_basic.mako
@@ -4,7 +4,7 @@
 % if value.type in (BasicNumericTypes.INTEGER, BasicNumericTypes.RATIONAL):
     ${value.data}\
 % elif value.type in (BasicStringTypes.TEXT, BasicStringTypes.CHAR):
-    ${repr(value.data)}\
+    ${repr(value.data).replace("\\\\", "\\")}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     ${str(value.data)}\
 % elif value.type == BasicNothingTypes.NOTHING:

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -151,7 +151,7 @@ def test_parse_value_text():
 def test_parse_value_text_cast():
     parsed = parser.parse_value(r'"this\nis\na\nstring" :: text')
     assert parsed.type == BasicStringTypes.TEXT
-    assert parsed.data == "this\nis\na\nstring"
+    assert parsed.data == r"this\nis\na\nstring"
 
 
 def test_parse_value_char():


### PR DESCRIPTION
Fix incorrect formatting of escaped characters in DSL and python.

- Escaping must not be done in DSL.
- Example fixed problem python:
Wanted/given in testplan:
```python
\"
```
Generated:
```python
\\\"
```