### PR TITLE
Support not only strings as object keys

### DIFF
--- a/exercise/objects/evaluation/no-test.yaml
+++ b/exercise/objects/evaluation/no-test.yaml
@@ -1,0 +1,4 @@
+- tab: "Feedback"
+  contexts:
+    - statement: 'x = [[{"a"}], [{"b"}, {"c"}]]::array'
+    - statement: 'x = {{"a"}: [1::int32], {"b"}: [2::int32]}'

--- a/exercise/objects/evaluation/no-test.yaml
+++ b/exercise/objects/evaluation/no-test.yaml
@@ -1,5 +1,5 @@
 - tab: "Feedback"
   contexts:
     - statement: 'x = [[{"a"::char}], [{"b"::char}, {"c"::char}]]::array'
-    - statement: 'x = {{"a"}: [1::int32], {"b"}: [-1::int32]}'
+    - statement: 'x = {{"a"}: [1::int16], {"b"}: [0::int16]}'
     - statement: 'x = {{"a"}: [1::int32], {"b"}: "a"}'

--- a/exercise/objects/evaluation/no-test.yaml
+++ b/exercise/objects/evaluation/no-test.yaml
@@ -3,3 +3,5 @@
     - statement: 'x = [[{"a"::char}], [{"b"::char}, {"c"::char}]]::array'
     - statement: 'x = {{"a"}: [1::int16], {"b"}: [0::int16]}'
     - statement: 'x = {{"a"}: [1::int32], {"b"}: "a"}'
+    - expression: '{{"a"}: [1::int32], {"b"}: "a"}'
+      return-raw: '{{"a"}: [1::int32], {"b"}: "a"}'

--- a/exercise/objects/evaluation/no-test.yaml
+++ b/exercise/objects/evaluation/no-test.yaml
@@ -1,5 +1,5 @@
 - tab: "Feedback"
   contexts:
-    - statement: 'x = [[{"a"}], [{"b"}, {"c"}]]::array'
+    - statement: 'x = [[{"a"::char}], [{"b"::char}, {"c"::char}]]::array'
     - statement: 'x = {{"a"}: [1::int32], {"b"}: [-1::int32]}'
     - statement: 'x = {{"a"}: [1::int32], {"b"}: "a"}'

--- a/exercise/objects/evaluation/no-test.yaml
+++ b/exercise/objects/evaluation/no-test.yaml
@@ -1,4 +1,5 @@
 - tab: "Feedback"
   contexts:
     - statement: 'x = [[{"a"}], [{"b"}, {"c"}]]::array'
-    - statement: 'x = {{"a"}: [1::int32], {"b"}: [2::int32]}'
+    - statement: 'x = {{"a"}: [1::int32], {"b"}: [-1::int32]}'
+    - statement: 'x = {{"a"}: [1::int32], {"b"}: "a"}'

--- a/tested/datatypes/basic.py
+++ b/tested/datatypes/basic.py
@@ -11,7 +11,7 @@ class BasicNumericTypes(str, Enum):
 
 
 class BasicStringTypes(str, Enum):
-    CHAR = "character"
+    CHAR = "char"
     TEXT = "text"
     ANY = "any"  # Cannot be used in testplan.
 

--- a/tested/dsl/grammar.lark
+++ b/tested/dsl/grammar.lark
@@ -106,7 +106,7 @@ dict: "{" [dict_pair ("," dict_pair)*] "}"
 list: "[" [expr ("," expr)*] "]"
 set: "{" expr ("," expr)* "}"
 tuple: "(" [expr ("," expr)*] ")"
-dict_pair: string ":" expr
+dict_pair: expr ":" expr
 
 null: "null"
     | "undefined"

--- a/tested/dsl/statement.py
+++ b/tested/dsl/statement.py
@@ -10,7 +10,7 @@ from tested.datatypes import string_to_type, AllTypes, SequenceTypes, \
     BasicStringTypes, BasicBooleanTypes
 from tested.serialisation import Statement, Assignment, NumberType, Expression, \
     NothingType, Identifier, BooleanType, StringType, SequenceType, FunctionCall, \
-    ObjectType, FunctionType, VariableType, Value
+    ObjectType, FunctionType, VariableType, Value, ObjectKeyValuePair
 
 data_types = (
     "INTEGER", "RATIONAL", "CHAR", "TEXT", "BOOLEAN", "SEQUENCE", "SET", "MAP",
@@ -113,14 +113,17 @@ class Parser:
                             namespace=namespace,
                             arguments=args)
 
-    def analyse_dict(self, tree: Tree, allow_functions: bool = True) -> dict:
-        def analyse_pair(pair: Tree) -> tuple:
+    def analyse_dict(self, tree: Tree,
+                     allow_functions: bool = True) -> List[ObjectKeyValuePair]:
+        def analyse_pair(pair: Tree) -> ObjectKeyValuePair:
             if pair.data != 'dict_pair':
                 raise ParseError("Key-value pair expected in map")
-            return (self.analyse_expression(pair.children[0]).data,
-                    self.analyse_expression(pair.children[1], allow_functions))
+            return ObjectKeyValuePair(key=self.analyse_expression(pair.children[0],
+                                                                  allow_functions),
+                                      value=self.analyse_expression(
+                                          pair.children[1], allow_functions))
 
-        return dict(analyse_pair(pair) for pair in tree.children)
+        return [analyse_pair(pair) for pair in tree.children]
 
     def analyse_expression(self, tree: Union[Tree, Token],
                            allow_functions: bool = True) -> Expression:

--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -10,10 +10,10 @@ from typing import Any, Dict, List, Optional, Union, Tuple
 from yaml import safe_load
 
 from tested.datatypes import BasicBooleanTypes, BasicNumericTypes, \
-    BasicObjectTypes, BasicSequenceTypes, BasicStringTypes
+    BasicObjectTypes, BasicSequenceTypes, BasicStringTypes, StringTypes
 from tested.dsl.statement import Parser
 from tested.serialisation import ExceptionValue, Value, NothingType, StringType, \
-    BooleanType, NumberType, SequenceType, ObjectType
+    BooleanType, NumberType, SequenceType, ObjectType, ObjectKeyValuePair
 from tested.testplan import BaseOutput, Context, EmptyChannel, \
     ExceptionOutputChannel, FileUrl, GenericTextEvaluator, Output, Plan, Run, \
     RunTestcase, RunInput, RunOutput, Tab, Testcase, TextData, TextOutputChannel, \
@@ -381,8 +381,12 @@ class SchemaParser:
                 self._translate_value(part_value) for part_value in value
             ])
         else:
-            return ObjectType(type=BasicObjectTypes.MAP, data=dict(
-                (key, self._translate_value(val)) for key, val in value.items()
+            return ObjectType(type=BasicObjectTypes.MAP, data=list(
+                ObjectKeyValuePair(
+                    key=StringType(type=StringTypes.TEXT, data=key),
+                    value=self._translate_value(val)
+                )
+                for key, val in value.items()
             ))
 
     def _write_to_json_string(self, json_object: Any) -> str:

--- a/tested/languages/c/templates/values.c
+++ b/tested/languages/c/templates/values.c
@@ -41,33 +41,18 @@ void write_bool(FILE* out, bool value) {
 }
 
 void write_char(FILE* out, char value) {
-    if (value == '\'') {
-        const char* asString = format("character", %s);
-        fprintf(out, asString, "\"'\"");
-    } else {
-        const char* asString = format("character", %c);
-        fprintf(out, asString, value);
-    }
+    const char* asString = format("char", "%c");
+    fprintf(out, asString, value);
 }
 
 void write_signed_char(FILE* out, signed char value) {
-    if (value == '\'') {
-        const char* asString = format("int8", %s);
-        fprintf(out, asString, "\"'\"");
-    } else {
-        const char* asString = format("int8", %c);
-        fprintf(out, asString, value);
-    }
+    const char* asString = format("char", "%c");
+    fprintf(out, asString, value);
 }
 
 void write_unsigned_char(FILE* out, unsigned char value) {
-    if (value == '\'') {
-        const char* asString = format("uint8", %s);
-        fprintf(out, asString, "\"'\"");
-    } else {
-        const char* asString = format("uint8", %c);
-        fprintf(out, asString, value);
-    }
+    const char* asString = format("char", "%uc");
+    fprintf(out, asString, value);
 }
 
 void write_sint(FILE* out, short int value) {

--- a/tested/languages/c/templates/values.c
+++ b/tested/languages/c/templates/values.c
@@ -41,18 +41,23 @@ void write_bool(FILE* out, bool value) {
 }
 
 void write_char(FILE* out, char value) {
-    const char* asString = format("char", "%c");
-    fprintf(out, asString, value);
+    const char* asString = format("char", "%s");
+    char buffer[2];
+    sprintf(buffer, "%c", value);
+    char* result = str_replace(buffer, '"', "\\\"");
+    fprintf(out, asString, result);
+    free(result);
+
 }
 
 void write_signed_char(FILE* out, signed char value) {
-    const char* asString = format("char", "%c");
-    fprintf(out, asString, value);
+    const char* asString = format("int8", %d);
+    fprintf(out, asString, ((int) value));
 }
 
 void write_unsigned_char(FILE* out, unsigned char value) {
-    const char* asString = format("char", "%uc");
-    fprintf(out, asString, value);
+    const char* asString = format("uint8", %u);
+    fprintf(out, asString, ((unsigned int) value));
 }
 
 void write_sint(FILE* out, short int value) {
@@ -101,7 +106,7 @@ void write_float(FILE* out, float value) {
 }
 
 void write_double(FILE* out, double value) {
-    const char* asString = format("double_precision", %f);
+    const char* asString = format("double_precision", %lf);
     fprintf(out, asString, value);
 }
 

--- a/tested/languages/generator.py
+++ b/tested/languages/generator.py
@@ -16,7 +16,8 @@ from ..dodona import ExtendedMessage
 from ..internationalization import get_i18n_string
 from ..serialisation import (Value, SequenceType, Identifier, FunctionType,
                              FunctionCall, Expression, Statement, Assignment,
-                             NothingType, NamedArgument, ObjectType)
+                             NothingType, NamedArgument, ObjectType,
+                             ObjectKeyValuePair)
 from ..testplan import (EmptyChannel, IgnoredChannel, TextData, ProgrammedEvaluator,
                         SpecificEvaluator, Testcase, RunTestcase, Context,
                         ExceptionOutput, ValueOutput, Run)
@@ -191,8 +192,10 @@ def _prepare_expression(bundle: Bundle, expression: Expression) -> Expression:
         expression.data = [_prepare_expression(bundle, expr)
                            for expr in expression.data]
     elif isinstance(expression, ObjectType):
-        expression.data = dict((key, _prepare_expression(bundle, value))
-                               for key, value in expression.data.items())
+        expression.data = [ObjectKeyValuePair(
+            key=_prepare_expression(bundle, pair.key),
+            value=_prepare_expression(bundle, pair.value)
+        ) for pair in expression.data]
     return expression
 
 

--- a/tested/languages/haskell/templates/Values.hs
+++ b/tested/languages/haskell/templates/Values.hs
@@ -63,7 +63,7 @@ instance Typeable Integer where toType _ = "bigint"
 instance Typeable Int where toType _ = "integer"
 
 instance Typeable Bool where toType _ = "boolean"
-instance Typeable Char where toType _ = "character"
+instance Typeable Char where toType _ = "char"
 
 instance Typeable Text where toType _ = "text"
 instance {-# OVERLAPPABLE #-} Typeable String where toType _ = "text"

--- a/tested/languages/haskell/templates/Values.hs
+++ b/tested/languages/haskell/templates/Values.hs
@@ -46,7 +46,7 @@ instance (Typeable a) => Typeable (IO a) where
     -- Preferred function call to pass the IO monad results to the judge, avoid `unsafePerformIO`
     toJsonIO m = do
         unwrapped <- m
-        return ((toType unwrapped), (toJson unwrapped))
+        toJsonIO unwrapped
 
 instance Typeable W.Word8 where toType _ = "uint8"
 instance Typeable W.Word16 where toType _ = "uint16"

--- a/tested/languages/java/templates/Values.java
+++ b/tested/languages/java/templates/Values.java
@@ -81,10 +81,10 @@ public class Values {
         } else if (value instanceof Map) {
             type = "map";
             var elements = new ArrayList<String>();
-            for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) value).entrySet()) {
-                elements.add("\"" + entry.getKey().toString() + "\": " + encode(entry.getValue()));
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                elements.add("{ \"key\":" + encode(entry.getKey()) + ",\"value\": " + encode(entry.getValue()) + "}");
             }
-            data = "{" + String.join(", ", elements) + "}";
+            data = "[" + String.join(", ", elements) + "]";
         } else {
             type = "unknown";
             data = "\"" + escape(value.toString()) + "\"";

--- a/tested/languages/java/templates/Values.java
+++ b/tested/languages/java/templates/Values.java
@@ -2,6 +2,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -10,12 +11,24 @@ import java.util.stream.Collectors;
  */
 public class Values {
 
-    private static String encodeSequence(Iterable<Object> objects) {
+    private static String encodeSequence(Iterable<?> objects) {
         var results = new ArrayList<String>();
         for (Object obj : objects) {
             results.add(encode(obj));
         }
         return "[" + String.join(", ", results) + "]";
+    }
+
+    public static List<Object> getListFromArray(Object value) {
+        if (value instanceof Object[]) {
+            return Arrays.asList((Object[]) value);
+        }
+        int arrayLength = Array.getLength(value);
+        List<Object> list = new ArrayList<>();
+        for (int i = 0; i < arrayLength; i++) {
+            list.add(Array.get(value, i));
+        }
+        return list;
     }
         
     private static String escape(String string) {
@@ -41,7 +54,8 @@ public class Values {
             data = value.toString();
         } else if (value.getClass().isArray()) {
             type = "array";
-            data = encodeSequence(Arrays.asList((Object[]) value));
+            List<Object> list = new ArrayList<>();
+            data = encodeSequence(getListFromArray(value));
         } else if (value instanceof BigInteger) {
             type = "bigint";
             data = value.toString();
@@ -74,10 +88,10 @@ public class Values {
             data = "\"" + escape(value.toString()) + "\"";
         } else if (value instanceof List) {
             type = "list";
-            data = encodeSequence((Iterable<Object>) value);
+            data = encodeSequence((Iterable<?>) value);
         } else if (value instanceof Set) {
             type = "set";
-            data = encodeSequence((Iterable<Object>) value);
+            data = encodeSequence((Iterable<?>) value);
         } else if (value instanceof Map) {
             type = "map";
             var elements = new ArrayList<String>();

--- a/tested/languages/java/templates/Values.java
+++ b/tested/languages/java/templates/Values.java
@@ -67,7 +67,7 @@ public class Values {
             type = "double_precision";
             data = value.toString();
         } else if (value instanceof Character) {
-            type = "character";
+            type = "char";
             data = "\"" + escape(value.toString()) + "\"";
         } else if (value instanceof CharSequence) {
             type = "text";

--- a/tested/languages/java/templates/declaration.mako
+++ b/tested/languages/java/templates/declaration.mako
@@ -3,7 +3,7 @@
 <%! from tested.serialisation import VariableType, as_basic_type, resolve_to_basic, Value %>\
 <%! from tested.datatypes import AdvancedNumericTypes, AdvancedSequenceTypes  %>\
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
-<%page args="tp,value" />\
+<%page args="tp,value,inner=False" />\
 % if isinstance(tp, VariableType):
     ${tp.data}\
 % elif tp == AdvancedSequenceTypes.ARRAY:
@@ -15,37 +15,77 @@
 % elif tp in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
     BigDecimal\
 % elif tp == AdvancedNumericTypes.INT_8:
-    byte\
+    %if inner:
+        Byte\
+    %else:
+        byte\
+    %endif
 % elif tp in (AdvancedNumericTypes.U_INT_8, AdvancedNumericTypes.INT_16):
-    short\
+    %if inner:
+        Short\
+    %else:
+        short\
+    %endif
 % elif tp in (AdvancedNumericTypes.U_INT_16, AdvancedNumericTypes.INT_32):
-    int\
+    %if inner:
+        Integer\
+    %else:
+        int\
+    %endif
 % elif tp in (AdvancedNumericTypes.U_INT_32, AdvancedNumericTypes.INT_64):
+    %if inner:
+        Long\
+    %else:
+        long\
+    %endif
     long\
 % elif tp == AdvancedNumericTypes.SINGLE_PRECISION:
-    float\
+    %if inner:
+        Float\
+    %else:
+        float\
+    %endif
 % elif tp == "Object":
     Object\
 % else:
     <% basic = resolve_to_basic(tp) %>\
     % if basic == BasicSequenceTypes.SEQUENCE:
         <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        List<<%include file="declaration.mako" args="tp=type_,value=None"/>>\
+        List<<%include file="declaration.mako" args="tp=type_,value=None,inner=True"/>>\
     % elif basic == BasicSequenceTypes.SET:
         <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        Set<<%include file="declaration.mako" args="tp=type_,value=None"/>>\
+        Set<<%include file="declaration.mako" args="tp=type_,value=None,inner=True"/>>\
     % elif basic == BasicBooleanTypes.BOOLEAN:
-        boolean\
+        %if inner:
+            Boolean\
+        %else:
+            boolean\
+        %endif
     % elif basic == BasicStringTypes.TEXT:
         String\
     % elif basic == BasicStringTypes.CHAR:
-        char\
+        %if inner:
+            Character\
+        %else:
+            char\
+        %endif
     % elif basic == BasicNumericTypes.INTEGER:
-        long\
+        %if inner:
+            Long\
+        %else:
+            long\
+        %endif
     % elif basic == BasicNumericTypes.RATIONAL:
-        double\
+        %if inner:
+            Double\
+        %else:
+            double\
+        %endif
     % elif basic == BasicObjectTypes.MAP:
-        Map${'<String, Object>'}\
+        <% key_type_ = (value.get_key_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
+        <% value_type_ = (value.get_value_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
+        Map<<%include file="declaration.mako" args="tp=key_type_,value=None,inner=True"/>, \
+        <%include file="declaration.mako" args="tp=value_type_,value=None,inner=True"/>>'\
     % elif basic in (BasicNothingTypes.NOTHING, BasicStringTypes.ANY):
         Object\
     % endif

--- a/tested/languages/java/templates/declaration.mako
+++ b/tested/languages/java/templates/declaration.mako
@@ -53,7 +53,7 @@
     % elif basic == BasicStringTypes.CHAR:
         ${("Character" if inner else "char")}\
     % elif basic == BasicNumericTypes.INTEGER:
-        ${("Long" if inner else "long")}\
+        ${("Integer" if inner else "int")}\
     % elif basic == BasicNumericTypes.RATIONAL:
         ${("Double" if inner else "double")}\
     % elif basic == BasicObjectTypes.MAP:

--- a/tested/languages/java/templates/declaration.mako
+++ b/tested/languages/java/templates/declaration.mako
@@ -3,89 +3,72 @@
 <%! from tested.serialisation import VariableType, as_basic_type, resolve_to_basic, Value %>\
 <%! from tested.datatypes import AdvancedNumericTypes, AdvancedSequenceTypes  %>\
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
-<%page args="tp,value,inner=False" />\
+<%page args="tp,value,nt=None,inner=False" />\
+<%!
+    def extract_type_tuple(type_, generic=True):
+        if isinstance(type_, tuple):
+            if generic:
+                return type_
+            else:
+                return "Object", False
+        else:
+            return type_, False
+%>\
 % if isinstance(tp, VariableType):
     ${tp.data}\
 % elif tp == AdvancedSequenceTypes.ARRAY:
-    <% type_ = value.get_content_type() %>\
-    <% assert value is not None, "Value is needed for arrays!" %>\
-    <%include file="declaration.mako" args="tp=type_,value=None"/>[]\
+    <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else nt if nt else 'Object' %>\
+    <% base_type, sub_type = extract_type_tuple(type_, False) %>\
+    <%include file="declaration.mako" args="tp=base_type,value=None,nt=sub_type,inner=False"/>[]\
 % elif tp in (AdvancedNumericTypes.U_INT_64, AdvancedNumericTypes.BIG_INT):
     BigInteger\
 % elif tp in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
     BigDecimal\
 % elif tp == AdvancedNumericTypes.INT_8:
-    %if inner:
-        Byte\
-    %else:
-        byte\
-    %endif
+    ${("Byte" if inner else "byte")}\
 % elif tp in (AdvancedNumericTypes.U_INT_8, AdvancedNumericTypes.INT_16):
-    %if inner:
-        Short\
-    %else:
-        short\
-    %endif
+    ${("Short" if inner else "short")}\
 % elif tp in (AdvancedNumericTypes.U_INT_16, AdvancedNumericTypes.INT_32):
-    %if inner:
-        Integer\
-    %else:
-        int\
-    %endif
+    ${("Integer" if inner else "int")}\
 % elif tp in (AdvancedNumericTypes.U_INT_32, AdvancedNumericTypes.INT_64):
-    %if inner:
-        Long\
-    %else:
-        long\
-    %endif
-    long\
+    ${("Long" if inner else "long")}\
 % elif tp == AdvancedNumericTypes.SINGLE_PRECISION:
-    %if inner:
-        Float\
-    %else:
-        float\
-    %endif
+    ${("Float" if inner else "float")}\
 % elif tp == "Object":
     Object\
 % else:
     <% basic = resolve_to_basic(tp) %>\
     % if basic == BasicSequenceTypes.SEQUENCE:
-        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        List<<%include file="declaration.mako" args="tp=type_,value=None,inner=True"/>>\
+        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else nt if nt else 'Object' %>\
+        <% base_type, sub_type = extract_type_tuple(type_) %>\
+        List<<%include file="declaration.mako" args="tp=base_type,value=None,nt=sub_type,inner=True"/>>\
     % elif basic == BasicSequenceTypes.SET:
-        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        Set<<%include file="declaration.mako" args="tp=type_,value=None,inner=True"/>>\
+        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else nt if nt else 'Object' %>\
+        <% base_type, sub_type = extract_type_tuple(type_) %>\
+        Set<<%include file="declaration.mako" args="tp=base_type,value=None,nt=sub_type,inner=True"/>>\
     % elif basic == BasicBooleanTypes.BOOLEAN:
-        %if inner:
-            Boolean\
-        %else:
-            boolean\
-        %endif
+        ${("Boolean" if inner else "boolean")}\
     % elif basic == BasicStringTypes.TEXT:
         String\
     % elif basic == BasicStringTypes.CHAR:
-        %if inner:
-            Character\
-        %else:
-            char\
-        %endif
+        ${("Character" if inner else "char")}\
     % elif basic == BasicNumericTypes.INTEGER:
-        %if inner:
-            Long\
-        %else:
-            long\
-        %endif
+        ${("Long" if inner else "long")}\
     % elif basic == BasicNumericTypes.RATIONAL:
-        %if inner:
-            Double\
-        %else:
-            double\
-        %endif
+        ${("Double" if inner else "double")}\
     % elif basic == BasicObjectTypes.MAP:
-        <% key_type_ = (value.get_key_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        <% value_type_ = (value.get_value_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        Map<<%include file="declaration.mako" args="tp=key_type_,value=None,inner=True"/>, \
-        <%include file="declaration.mako" args="tp=value_type_,value=None,inner=True"/>>'\
+        % if isinstance(value, get_args(Value)):
+            <% key_type_ = value.get_key_type() or "Object" %>\
+            <% value_type_ = value.get_value_type() or "Object" %>\
+        % elif nt:
+            <% key_type_, value_type_ = nt %>\
+        % else:
+            <% key_type_, value_type_ = "Object", "Object" %>\
+        % endif
+        <% key_base_type, key_sub_type = extract_type_tuple(key_type_) %>\
+        <% value_base_type, value_sub_type = extract_type_tuple(value_type_) %>\
+        Map<<%include file="declaration.mako" args="tp=key_base_type,value=None,nt=key_sub_type,inner=True"/>, \
+        <%include file="declaration.mako" args="tp=value_base_type,value=None,nt=value_sub_type,inner=True"/>>\
     % elif basic in (BasicNothingTypes.NOTHING, BasicStringTypes.ANY):
         Object\
     % endif

--- a/tested/languages/java/templates/statement.mako
+++ b/tested/languages/java/templates/statement.mako
@@ -16,5 +16,5 @@
     % if full:
         <%include file="declaration.mako" args="tp=statement.type, value=statement.expression" /> \
     % endif
-    ${statement.variable} = <%include file="statement.mako" args="statement=statement.expression"/>;\
+    ${statement.variable} = <%include file="statement.mako" args="statement=statement.expression"/>\
 % endif

--- a/tested/languages/java/templates/value.mako
+++ b/tested/languages/java/templates/value.mako
@@ -5,6 +5,8 @@
 ## First, add support for the advanced types in Java.
 % if value.type == AdvancedSequenceTypes.ARRAY:
     new <%include file="declaration.mako" args="tp=value.type,value=value"/>{<%include file="value_arguments.mako" args="arguments=value.data"/>}\
+% elif value.type == AdvancedNumericTypes.SINGLE_PRECISION:
+    ${value.data}f\
 % elif value.type == AdvancedNumericTypes.INT_8:
     (byte) ${value.data}\
 % elif value.type in (AdvancedNumericTypes.U_INT_8, AdvancedNumericTypes.INT_16):

--- a/tested/languages/java/templates/value.mako
+++ b/tested/languages/java/templates/value.mako
@@ -5,6 +5,14 @@
 ## First, add support for the advanced types in Java.
 % if value.type == AdvancedSequenceTypes.ARRAY:
     new <%include file="declaration.mako" args="tp=value.type,value=value"/>{<%include file="value_arguments.mako" args="arguments=value.data"/>}\
+% elif value.type == AdvancedNumericTypes.INT_8:
+    (byte) ${value.data}
+% elif value.type in (AdvancedNumericTypes.U_INT_8, AdvancedNumericTypes.INT_16):
+    (short) ${value.data}
+% elif value.type in (AdvancedNumericTypes.U_INT_16, AdvancedNumericTypes.INT_32):
+    ${value.data}
+% elif value.type in (AdvancedNumericTypes.U_INT_32, AdvancedNumericTypes.INT_64):
+    ${value.data}L
 % elif value.type in (AdvancedNumericTypes.U_INT_64, AdvancedNumericTypes.BIG_INT):
     new BigInteger("${value.data}")
 % elif value.type in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):

--- a/tested/languages/java/templates/value.mako
+++ b/tested/languages/java/templates/value.mako
@@ -6,17 +6,17 @@
 % if value.type == AdvancedSequenceTypes.ARRAY:
     new <%include file="declaration.mako" args="tp=value.type,value=value"/>{<%include file="value_arguments.mako" args="arguments=value.data"/>}\
 % elif value.type == AdvancedNumericTypes.INT_8:
-    (byte) ${value.data}
+    (byte) ${value.data}\
 % elif value.type in (AdvancedNumericTypes.U_INT_8, AdvancedNumericTypes.INT_16):
-    (short) ${value.data}
+    (short) ${value.data}\
 % elif value.type in (AdvancedNumericTypes.U_INT_16, AdvancedNumericTypes.INT_32):
-    ${value.data}
+    ${value.data}\
 % elif value.type in (AdvancedNumericTypes.U_INT_32, AdvancedNumericTypes.INT_64):
-    ${value.data}L
+    ${value.data}L\
 % elif value.type in (AdvancedNumericTypes.U_INT_64, AdvancedNumericTypes.BIG_INT):
-    new BigInteger("${value.data}")
+    new BigInteger("${value.data}")\
 % elif value.type in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
-    new BigDecimal("${value.data}")
+    new BigDecimal("${value.data}")\
 % else:
     ## Handle the base types
     <% basic = as_basic_type(value) %>\

--- a/tested/languages/java/templates/value_basic.mako
+++ b/tested/languages/java/templates/value_basic.mako
@@ -9,6 +9,7 @@
 %>\
 % if value.type == BasicNumericTypes.INTEGER:
     ## Basic heuristic for long/int
+    ## TODO: Discuss which type we want to use, because Java conversion problems with generic types
     % if len(str(value.data)) >= 10:
         ${value.data}L\
     % else:

--- a/tested/languages/java/templates/value_basic.mako
+++ b/tested/languages/java/templates/value_basic.mako
@@ -8,13 +8,7 @@
         return text.replace("'", "\\'")
 %>\
 % if value.type == BasicNumericTypes.INTEGER:
-    ## Basic heuristic for long/int
-    ## TODO: Discuss which type we want to use, because Java conversion problems with generic types
-    % if len(str(value.data)) >= 10:
-        ${value.data}L\
-    % else:
-        ${value.data}\
-    % endif
+    ${value.data}\
 % elif value.type == BasicNumericTypes.RATIONAL:
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:

--- a/tested/languages/java/templates/value_basic.mako
+++ b/tested/languages/java/templates/value_basic.mako
@@ -30,8 +30,9 @@
     Set.of(<%include file="value_arguments.mako" args="arguments=value.data" />)\
 % elif value.type == BasicObjectTypes.MAP:
     Map.of(\
-    % for key, item in value.data.items():
-        "${key}", <%include file="statement.mako" args="statement=item" />\
+    % for pair in value.data:
+        <%include file="statement.mako" args="statement=pair.key" />, \
+        <%include file="statement.mako" args="statement=pair.value" />\
         % if not loop.last:
             , \
         % endif

--- a/tested/languages/javascript/config.json
+++ b/tested/languages/javascript/config.json
@@ -25,7 +25,7 @@
   "datatypes": {
     "integer": "supported",
     "rational": "supported",
-    "char": "supported",
+    "char": "unsupported",
     "text": "supported",
     "boolean": "supported",
     "sequence": "supported",

--- a/tested/languages/javascript/templates/value_basic.mako
+++ b/tested/languages/javascript/templates/value_basic.mako
@@ -22,8 +22,9 @@
     ])\
 % elif value.type == BasicObjectTypes.MAP:
     {\
-    % for key, item in value.data.items():
-        "${key}": <%include file="statement.mako" args="statement=item" />\
+    % for pair in value.data:
+        <%include file="statement.mako" args="statement=pair.key" />: \
+        <%include file="statement.mako" args="statement=pair.value" />\
         % if not loop.last:
             , \
         % endif

--- a/tested/languages/javascript/templates/values.js
+++ b/tested/languages/javascript/templates/values.js
@@ -33,22 +33,25 @@ function encode(value) {
             type = "set";
             value = Array.from(value).map(encode);
         } else if (value instanceof Map) {
-            type = "set";
+            type = "map";
             value = Array
-                .from(value)
-                .reduce(
-                    (obj, [key, value]) => (
-                        // Be careful! Maps can have non-String keys; object literals can't.
-                        Object.assign(obj, { [key]: encode(value) })
-                    ),
-                    {}
-                );
+                    .from(value)
+                    .map(([key, value]) => {
+                                return {
+                                    key: encode(key),
+                                    value: encode(value)
+                                };
+                            }
+                    );
         } else {
             type = "map";
             // Process the elements of the object.
-            for (let [key, v] of Object.entries(value)) {
-                value[key] = encode(v);
-            } 
+            value = Object.entries(value).map(([key, value]) => {
+                return {
+                    key: encode(key),
+                    value: encode(value)
+                };
+            });
         }
     } else {
         type = "unknown";

--- a/tested/languages/kotlin/templates/Values.kt
+++ b/tested/languages/kotlin/templates/Values.kt
@@ -79,7 +79,7 @@ private fun internalEncode(value: Any?): Array<String> {
         type = "double_precision"
         data = value.toString()
     } else if (value is Char) {
-        type = "character"
+        type = "char"
         data = String.format("\"%s\"", escape(value.toString()))
     } else if (value is CharSequence) {
         type = "text"

--- a/tested/languages/kotlin/templates/Values.kt
+++ b/tested/languages/kotlin/templates/Values.kt
@@ -94,10 +94,10 @@ private fun internalEncode(value: Any?): Array<String> {
         type = "map"
         data = value.asSequence()
                 .map { e ->
-                    String.format("\"%s\": %s", e.key.toString(),
+                    String.format("{\"key\": %s, \"value\": %s }", encode(e.key),
                             encode(e.value))
                 }
-                .joinToString(separator = ", ", prefix = "{", postfix = "}")
+                .joinToString(separator = ", ", prefix = "[", postfix = "]")
     } else {
         type = "unknown"
         data = String.format("\"%s\"", escape(value.toString()));

--- a/tested/languages/kotlin/templates/declaration.mako
+++ b/tested/languages/kotlin/templates/declaration.mako
@@ -50,7 +50,7 @@
     % elif basic == BasicStringTypes.CHAR:
         Char?\
     % elif basic == BasicNumericTypes.INTEGER:
-        Long?\
+        Int?\
     % elif basic == BasicNumericTypes.RATIONAL:
         Double?\
     % elif basic == BasicObjectTypes.MAP:

--- a/tested/languages/kotlin/templates/declaration.mako
+++ b/tested/languages/kotlin/templates/declaration.mako
@@ -3,13 +3,20 @@
 <%! from tested.serialisation import VariableType, as_basic_type, resolve_to_basic, Value %>\
 <%! from tested.datatypes import AdvancedNumericTypes, AdvancedSequenceTypes  %>\
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
-<%page args="tp,value" />\
+<%page args="tp,value,nt=None,inner=False" />\
+<%!
+    def extract_type_tuple(type_):
+        if isinstance(type_, tuple):
+            return type_
+        else:
+            return type_, False
+%>\
 % if isinstance(tp, VariableType):
     ${tp.data}?\
 % elif tp == AdvancedSequenceTypes.ARRAY:
-    <% type_ = value.get_content_type() %>\
-    <% assert value is not None, "Value is needed for arrays!" %>\
-    Array<<%include file="declaration.mako" args="tp=type_,value=None"/>>?\
+    <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else nt if nt else 'Object' %>\
+    <% base_type, sub_type = extract_type_tuple(type_) %>\
+    Array<<%include file="declaration.mako" args="tp=base_type,value=None,nt=sub_type,inner=True"/>>?\
 % elif tp in (AdvancedNumericTypes.U_INT_64, AdvancedNumericTypes.BIG_INT):
     BigInteger?\
 % elif tp in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
@@ -29,11 +36,13 @@
 % else:
     <% basic = resolve_to_basic(tp) %>\
     % if basic == BasicSequenceTypes.SEQUENCE:
-        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        List<<%include file="declaration.mako" args="tp=type_,value=None"/>>?\
+        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else nt if nt else 'Object' %>\
+        <% base_type, sub_type = extract_type_tuple(type_) %>\
+        List<<%include file="declaration.mako" args="tp=base_type,value=None,nt=sub_type,inner=True"/>>?\
     % elif basic == BasicSequenceTypes.SET:
-        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        Set<<%include file="declaration.mako" args="tp=type_,value=None"/>>?\
+        <% type_ = (value.get_content_type() or "Object") if isinstance(value, get_args(Value)) else nt if nt else 'Object' %>\
+        <% base_type, sub_type = extract_type_tuple(type_) %>\
+        Set<<%include file="declaration.mako" args="tp=base_type,value=None,nt=sub_type,inner=True"/>>\
     % elif basic == BasicBooleanTypes.BOOLEAN:
         Boolean?\
     % elif basic == BasicStringTypes.TEXT:
@@ -45,10 +54,18 @@
     % elif basic == BasicNumericTypes.RATIONAL:
         Double?\
     % elif basic == BasicObjectTypes.MAP:
-        <% key_type_ = (value.get_key_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        <% value_type_ = (value.get_value_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
-        Map<<%include file="declaration.mako" args="tp=key_type_,value=None"/>, \
-        <%include file="declaration.mako" args="tp=value_type_,value=None"/>?>\
+        % if isinstance(value, get_args(Value)):
+            <% key_type_ = value.get_key_type() or "Object" %>\
+            <% value_type_ = value.get_value_type() or "Object" %>\
+        % elif nt:
+            <% key_type_, value_type_ = nt %>\
+        % else:
+            <% key_type_, value_type_ = "Object", "Object" %>\
+        % endif
+        <% key_base_type, key_sub_type = extract_type_tuple(key_type_) %>\
+        <% value_base_type, value_sub_type = extract_type_tuple(value_type_) %>\
+        Map<<%include file="declaration.mako" args="tp=key_base_type,value=None,nt=key_sub_type,inner=True"/>, \
+        <%include file="declaration.mako" args="tp=value_base_type,value=None,nt=value_sub_type,inner=True"/>>?\
     % elif basic in (BasicNothingTypes.NOTHING, BasicStringTypes.ANY):
         Any?\
     % endif

--- a/tested/languages/kotlin/templates/declaration.mako
+++ b/tested/languages/kotlin/templates/declaration.mako
@@ -45,7 +45,10 @@
     % elif basic == BasicNumericTypes.RATIONAL:
         Double?\
     % elif basic == BasicObjectTypes.MAP:
-        Map${'<String, Any?>?'}\
+        <% key_type_ = (value.get_key_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
+        <% value_type_ = (value.get_value_type() or "Object") if isinstance(value, get_args(Value)) else "Object" %>\
+        Map<<%include file="declaration.mako" args="tp=key_type_,value=None"/>, \
+        <%include file="declaration.mako" args="tp=value_type_,value=None"/>?>\
     % elif basic in (BasicNothingTypes.NOTHING, BasicStringTypes.ANY):
         Any?\
     % endif

--- a/tested/languages/kotlin/templates/statement.mako
+++ b/tested/languages/kotlin/templates/statement.mako
@@ -16,5 +16,5 @@
     % if full:
         var \
     % endif
-    ${statement.variable} = <%include file="statement.mako" args="statement=statement.expression"/>;\
+    ${statement.variable} = <%include file="statement.mako" args="statement=statement.expression"/>\
 % endif

--- a/tested/languages/kotlin/templates/value.mako
+++ b/tested/languages/kotlin/templates/value.mako
@@ -4,11 +4,11 @@
 <%page args="value" />\
 ## First, add support for the advanced types in Kotlin.
 % if value.type == AdvancedSequenceTypes.ARRAY:
-    arrayOf(<%include file="value_arguments.mako" args="arguments=value.data"/>)
+    arrayOf(<%include file="value_arguments.mako" args="arguments=value.data"/>)\
 % elif value.type in (AdvancedNumericTypes.U_INT_64, AdvancedNumericTypes.BIG_INT):
-    BigInteger("${value.data}")
+    BigInteger("${value.data}")\
 % elif value.type in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
-    BigDecimal("${value.data}")
+    BigDecimal("${value.data}")\
 % else:
     ## Handle the base types
     <% basic = as_basic_type(value) %>\

--- a/tested/languages/kotlin/templates/value_basic.mako
+++ b/tested/languages/kotlin/templates/value_basic.mako
@@ -8,12 +8,7 @@
         return text.replace("'", "\\'")
 %>\
 % if value.type == BasicNumericTypes.INTEGER:
-    ## Basic heuristic for long/int
-    % if len(str(value.data)) >= 10:
-        ${value.data}L\
-    % else:
-        ${value.data}\
-    % endif
+    ${value.data}\
 % elif value.type == BasicNumericTypes.RATIONAL:
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:

--- a/tested/languages/kotlin/templates/value_basic.mako
+++ b/tested/languages/kotlin/templates/value_basic.mako
@@ -30,8 +30,9 @@
     setOf(<%include file="value_arguments.mako" args="arguments=value.data" />)\
 % elif value.type == BasicObjectTypes.MAP:
     mapOf(\
-    % for key, item in value.data.items():
-        Pair("${key}", <%include file="statement.mako" args="statement=item" />)\
+    % for pair in value.data:
+        Pair(<%include file="statement.mako" args="statement=pair.key" />, \
+        <%include file="statement.mako" args="statement=pair.value" />)\
         % if not loop.last:
             , \
         % endif

--- a/tested/languages/python/config.json
+++ b/tested/languages/python/config.json
@@ -24,7 +24,7 @@
 
     "integer": "supported",
     "rational": "supported",
-    "char": "supported",
+    "char": "unsupported",
     "text": "supported",
     "boolean": "supported",
     "sequence": "supported",

--- a/tested/languages/python/templates/value_basic.mako
+++ b/tested/languages/python/templates/value_basic.mako
@@ -15,8 +15,9 @@
     {<%include file="value_arguments.mako" args="arguments=value.data" />}\
 % elif value.type == BasicObjectTypes.MAP:
     {\
-    % for key, item in value.data.items():
-        "${key}": <%include file="statement.mako" args="statement=item" />\
+    % for pair in value.data:
+        <%include file="statement.mako" args="statement=pair.key" />: \
+        <%include file="statement.mako" args="statement=pair.value" />\
         % if not loop.last:
             , \
         % endif

--- a/tested/languages/python/templates/values.py
+++ b/tested/languages/python/templates/values.py
@@ -36,7 +36,10 @@ def encode(value):
         data_ = [encode(x) for x in value]
     elif isinstance(value, dict):
         type_ = "map"
-        data_ = {str(k): encode(v) for k, v in value.items()}
+        data_ = [{
+            "key":   encode(k),
+            "value": encode(v)
+        } for k, v in value.items()]
     else:
         type_ = "unknown"
         data_ = str(value)
@@ -58,7 +61,7 @@ def send_exception(stream, exception):
     tracer = io.StringIO()
     traceback.print_tb(exception.__traceback__, file=tracer)
     data = {
-        "message": str(exception),
+        "message":    str(exception),
         "stacktrace": f"{exception.__class__.__name__}: {exception}\n"
                       f"{tracer.getvalue()}"
     }

--- a/tested/manual.py
+++ b/tested/manual.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from .configs import DodonaConfig
 from .main import run
 
-exercise_dir = "exercise/echo-function"
+exercise_dir = "exercise/objects"
 
 
 def read_config() -> DodonaConfig:
@@ -21,13 +21,13 @@ def read_config() -> DodonaConfig:
     return DodonaConfig(**{
         "memory_limit":         536870912,
         "time_limit":           60,
-        "programming_language": 'python',
+        "programming_language": 'java',
         "natural_language":     'nl',
         "resources":            Path(exercise_dir, 'evaluation'),
-        "source":               Path(exercise_dir, 'solution/correct.py'),
+        "source":               Path(exercise_dir, 'solution/correct.java'),
         "judge":                Path('.'),
         "workdir":              Path('workdir'),
-        "plan_name":            "two-specific.tson",
+        "plan_name":            "no-test.yaml",
         "options":              {
             "parallel":       True,
             "mode":           "batch",

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -545,7 +545,8 @@ def to_python_comparable(value: Optional[Value]):
     if basic_type == BasicNumericTypes.INTEGER:
         return value.data
     if basic_type in (BasicBooleanTypes.BOOLEAN, BasicStringTypes.TEXT,
-                      BasicNothingTypes.NOTHING, BasicStringTypes.ANY):
+                      BasicNothingTypes.NOTHING, BasicStringTypes.ANY,
+                      BasicStringTypes.CHAR):
         return value.data
 
     raise AssertionError(f"Unknown value type: {value}")

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -374,6 +374,7 @@ ObjectType.__pydantic_model__.update_forward_refs()
 SequenceType.__pydantic_model__.update_forward_refs()
 NamedArgument.__pydantic_model__.update_forward_refs()
 FunctionCall.__pydantic_model__.update_forward_refs()
+ObjectKeyValuePair.__pydantic_model__.update_forward_refs()
 
 
 def as_basic_type(value: Value) -> Value:

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -525,7 +525,8 @@ def to_python_comparable(value: Optional[Value]):
     if basic_type == BasicSequenceTypes.SET:
         return {to_python_comparable(x) for x in value.data}
     if basic_type == BasicObjectTypes.MAP:
-        return {key: to_python_comparable(val) for key, val in value.data.items()}
+        return [(to_python_comparable(pair.key), to_python_comparable(pair.value))
+                for pair in value.data]
     if basic_type == BasicNumericTypes.RATIONAL:
         return ComparableFloat(float(value.data))
     if basic_type == BasicNumericTypes.INTEGER:

--- a/tested/testplan.py
+++ b/tested/testplan.py
@@ -340,7 +340,8 @@ class Output(BaseOutput):
             if isinstance(value, SequenceType):
                 return all(_only_values(va) for va in value.data)
             if isinstance(value, ObjectType):
-                return all(_only_values(va) for k, va in value.data.items())
+                return all(_only_values(pair.key) and _only_values(pair.value)
+                           for pair in value.data)
 
             return True
 

--- a/tested/utils.py
+++ b/tested/utils.py
@@ -7,9 +7,10 @@ import string
 import typing
 from decimal import Decimal
 from os import PathLike
+from itertools import zip_longest
 from pathlib import Path
 from typing import (IO, Union, Generator, TypeVar, Generic, Optional, Mapping,
-                    Iterable, List, Callable)
+                    Iterable, List, Callable, Any)
 
 import itertools
 import sys
@@ -295,35 +296,149 @@ def safe_get(l: List[T], index: int) -> Optional[T]:
 
 def sorted_no_duplicates(iterable: Iterable[T],
                          key: Optional[Callable[[T], K]] = None) -> List[T]:
+    # Identity key function
     def identity(x: T) -> T:
         return x
 
-    def any_sortable(x: K) -> typing.Tuple[bool, bool, bool, bool, bool, K]:
-        return (
-            x is not None,  # First all None, then bool
-            not isinstance(x, (int, float, Decimal)),  # Then numbers
-            not isinstance(x, str),  # Then strings
-            not isinstance(x, tuple),  # Then tuples
-            not isinstance(x, list),  # Then lists
-            x  # Original sort value
-        )
+    # Order functions
+    def type_order(x: Any) -> int:
+        """
+        Determine order for different types
+        :param x: value to check
+        :return: order index of type
+        """
+        if x is None:
+            return 0
+        elif isinstance(x, (int, float, Decimal)):
+            return 1
+        elif isinstance(x, str):
+            return 2
+        elif isinstance(x, tuple):
+            return 3
+        elif isinstance(x, list):
+            return 4
+        else:
+            return 5
 
+    def order_iterable(iter0: Iterable[Any], iter1: Iterable[Any]) -> int:
+        """
+        Determine order between two iterables
+
+        :param iter0: first iterable
+        :param iter1: second iterable
+        :return: 1 if iter0 < iter1 else -1 if iter0 > iter1 else 0
+        """
+        for x, y in zip_longest(iter0, iter1):
+            cmp = order(x, y)
+            if cmp == 0:
+                continue
+            else:
+                return cmp
+        return 0
+
+    def order(x: Any, y: Any) -> int:
+        """
+        Determine order between two types
+
+        :param x: first value
+        :param x: second value
+        :return: 1 if x < y else -1 if x > y else 0
+        """
+        t_x, t_y = type_order(x), type_order(y)
+        if t_x < t_y:
+            return 1
+        elif t_x > t_y:
+            return -1
+        elif not isinstance(x, str) and isinstance(x, Iterable):
+            return order_iterable(x, y)
+        elif x < y:
+            return 1
+        elif x > y:
+            return -1
+        else:
+            return 0
+
+    # Sort functions, custom implementation needed for efficient recursive ordering
+    # of values that have different types
+    def insertion_sort(list_t: List[T], start: int, end: int) -> List[T]:
+        """
+        Insertion sort
+        :param list_t: list to sort
+        :param start: start of range to sort
+        :param end: end of range to sort
+        :return: the list itself
+        """
+        for i in range(start + 1, end):
+            j = i - 1
+            item = list_t[i]
+            item_key = key(item)
+            while j >= start and order(key(list_t[j]), item_key) < 0:
+                list_t[j + 1] = list_t[j]
+                j -= 1
+            list_t[j + 1] = item
+        return list_t
+
+    def merge(to_list: List[T], from_list: List[T], start: int, middle: int,
+              end: int):
+        """
+        Merge two sorted sublist to sorted list
+
+        :param to_list: output list
+        :param from_list: input list
+        :param start: start of first half
+        :param middle: end of first half, start of second half
+        :param end: end of second half
+        :return: No return value
+        """
+        i, j, k = start, middle, start
+        while i < middle and j < end:
+            if order(key(from_list[i]), key(from_list[j])) > 0:
+                to_list[k] = from_list[i]
+                i += 1
+            else:
+                to_list[k] = from_list[j]
+                j += 1
+            k += 1
+        if i < middle:
+            to_list[k:end] = from_list[i:middle]
+        else:
+            to_list[k:end] = from_list[j:end]
+
+    def timsort(list_t: List[T], timgroup: int = 32) -> List[T]:
+        """
+        Time sort algorithm
+        :param list_t: the modifiable list to sort
+        :param timgroup: the number of elements to sort with insertion sort
+        :return: The sort list
+        """
+        len_list_t = len(list_t)
+        for i in range(0, len_list_t, timgroup):
+            insertion_sort(list_t, i, min(i + timgroup, len_list_t))
+        copy = list(list_t)
+        while timgroup < len_list_t:
+            for start in range(0, len_list_t, 2 * timgroup):
+                middle = min(len_list_t, start + timgroup)
+                end = min(len_list_t, start + 2 * timgroup)
+                merge(list_t, copy, start, middle, end)
+            list_t, copy = copy, list_t
+            timgroup *= 2
+        return copy
+
+    # Check if key function is not none
     if key is None:
         key = identity
 
-    def _key(x):
-        return any_sortable(key(x))
-
-    first, key_last, no_dup = True, None, []
-    for v in sorted(iterable, key=_key):
+    # Sort and filterout duplicates
+    first, last_key, no_dup, list_iter = True, None, [], list(iterable)
+    for v in timsort(list_iter):
         if not first:
-            key_v = _key(v)
-            if key_v == key_last:
+            key_v = key(v)
+            if order(key_v, last_key) == 0:
                 continue
             else:
                 no_dup.append(v)
-                key_last = key_v
+                last_key = key_v
         else:
-            first = False
+            first, last_key = False, key(v)
             no_dup.append(v)
     return no_dup

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -2,7 +2,7 @@ import pytest
 
 from tested.datatypes import AdvancedNumericTypes, BasicNumericTypes
 from tested.dsl import SchemaParser, ParseError
-from tested.serialisation import Assignment, FunctionCall
+from tested.serialisation import Assignment, FunctionCall, ObjectType
 from tested.testplan import _PlanModel
 
 parser = SchemaParser()
@@ -255,7 +255,6 @@ def test_statement():
     assert isinstance(test1.input, FunctionCall)
 
 
-
 def test_invalid_yaml():
     yaml_str = """
 - tab: "Tab"
@@ -302,3 +301,28 @@ def test_invalid_mutual_exclusive_context_testcase():
         translate(yaml_str)
     assert e.type == SystemExit
     assert e.value.code != 0
+
+
+def test_statement_with_yaml_dict():
+    yaml_str = """
+- tab: "Feedback"
+  contexts:
+  - expression: "get_dict()"
+    return:
+        alpha: 5
+        beta: 6
+"""
+    json_str = translate(yaml_str)
+    plan = _PlanModel.parse_raw(json_str).__root__
+    assert len(plan.tabs) == 1
+    tab = plan.tabs[0]
+    assert len(tab.runs) == 1
+    run = tab.runs[0]
+    assert not run.run.input.main_call
+    testcases = run.contexts[0].testcases
+    assert len(testcases) == 1
+    test = testcases[0]
+    assert isinstance(test.input, FunctionCall)
+    assert isinstance(test.output.result.value, ObjectType)
+
+    pass

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -23,7 +23,7 @@ from tested.languages.config import TypeSupport
 from tested.languages.templates import find_and_write_template, path_to_templates
 from tested.serialisation import NumberType, Value, parse_value, StringType, \
     BooleanType, SequenceType, ObjectType, \
-    NothingType, as_basic_type, to_python_comparable
+    NothingType, as_basic_type, to_python_comparable, ObjectKeyValuePair
 from tested.testplan import Plan
 from tests.manual_utils import configuration, mark_haskell
 
@@ -98,9 +98,12 @@ def test_basic_types(language, tmp_path: Path, pytestconfig):
             NumberType(type=BasicNumericTypes.INTEGER, data=20)
         ]))
     if type_map[BasicObjectTypes.MAP] != TypeSupport.UNSUPPORTED:
-        types.append(ObjectType(type=BasicObjectTypes.MAP, data={
-            "data": NumberType(type=BasicNumericTypes.INTEGER, data=5)
-        }))
+        types.append(ObjectType(type=BasicObjectTypes.MAP, data=[
+            ObjectKeyValuePair(
+                key=StringType(type=BasicStringTypes.TEXT, data="data"),
+                value=NumberType(type=BasicNumericTypes.INTEGER, data=5)
+            )
+        ]))
     if type_map[BasicNothingTypes.NOTHING] != TypeSupport.UNSUPPORTED:
         types.append(NothingType())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 from tested.languages.config import limit_output
+from tested.utils import sorted_no_duplicates
 
 
-def test_limit_output_no_limit(pytestconfig):
+def test_limit_output_no_limit():
     text = "aaaaa\nbbbbb\nccccc".strip()
     limited = limit_output(output=text, max_lines=3, limit_characters=17)
     assert text == limited
@@ -31,3 +32,14 @@ def test_limit_output_no_limit(pytestconfig):
     assert "a\n...\nc" == limited
     assert len(limited) <= 7
     assert len(limited.splitlines()) <= 3
+
+
+def test_sort_no_duplicates():
+    data = ['a', 5, 8, 3, 7, 6, 28, 'b', 5, (True, False), ('a', ('b', 'c')), 'data', 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11,
+            12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 'a', 5, 8, 3, 7, 6, 28,
+            'b', 5, (True, False), ('a', ('b', 'c')), 'data', 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+            18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
+    expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+                28, 29, 30, 31, 32, 'a', 'b', 'data', (True, False), ('a', ('b', 'c'))]
+    result = sorted_no_duplicates(data)
+    assert expected == result


### PR DESCRIPTION
- Support not only strings as object keys
- Better support for most specific collection datatypes
- Add support for non-hashable python types as dictionary keys and set values
- Fix typo `character` name to `char`