### PR TITLE
Bug/escape chars

### DIFF
--- a/exercise/echo-function/evaluation/one-escape.tson
+++ b/exercise/echo-function/evaluation/one-escape.tson
@@ -1,0 +1,37 @@
+{
+  "tabs": [
+    {
+      "name": "Tab",
+      "runs": [
+        {
+          "contexts": [
+            {
+              "testcases": [
+                {
+                  "input": {
+                    "type": "function",
+                    "name": "echo",
+                    "arguments": [
+                      {
+                        "type": "text",
+                        "data": "\tinput-1\ninput-2\"\\\r"
+                      }
+                    ]
+                  },
+                  "output": {
+                    "result": {
+                      "value": {
+                        "type": "text",
+                        "data": "\tinput-1\ninput-2\"\\\r"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tested/dsl/statement.py
+++ b/tested/dsl/statement.py
@@ -141,7 +141,7 @@ class Parser:
                               data=float(token.value))
         elif token.type == 'ESCAPED_STRING':
             return StringType(type=BasicStringTypes.TEXT,
-                              data=token.value[1:-1])
+                              data=literal_eval(token.value))
         elif token.type == 'TRUE':
             return BooleanType(type=BasicBooleanTypes.BOOLEAN, data=True)
         elif token.type == 'FALSE':

--- a/tested/languages/c/templates/value.mako
+++ b/tested/languages/c/templates/value.mako
@@ -1,6 +1,7 @@
 ## Convert a Value to a literal type in C.
 <%! from tested.datatypes import AdvancedSequenceTypes, AdvancedNumericTypes, AdvancedStringTypes %>\
 <%! from tested.serialisation import as_basic_type %>\
+<%! from json import dumps %>\
 <%page args="value" />\
 <%!
     def escape_char(text):
@@ -10,7 +11,7 @@
 % if value.type == AdvancedSequenceTypes.ARRAY:
     new <%include file="declaration.mako" args="tp=value.type,value=value"/>{<%include file="value_arguments.mako" args="arguments=value.data"/>}\
 % elif value.type == AdvancedStringTypes.CHAR:
-    (char) '${escape_char(value.data)}'\
+    (char) '${escape_char(dumps(value.data)[1:-1])}'\
 % else:
     ## Handle the base types
     <% basic = as_basic_type(value) %>\

--- a/tested/languages/c/templates/value_basic.mako
+++ b/tested/languages/c/templates/value_basic.mako
@@ -1,16 +1,13 @@
 ## Convert a Value to a literal type in Java.
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
+<%! from json import dumps %>\
 <%page args="value" />\
-<%!
-    def escape_string(text):
-        return text.replace('"', '\\"')
-%>\
 % if value.type == BasicNumericTypes.INTEGER:
     ${value.data}\
 % elif value.type == BasicNumericTypes.RATIONAL:
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:
-    "${escape_string(value.data)}"\
+    ${dumps(value.data)}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     (bool) ${str(value.data).lower()}\
 % elif value.type == BasicNothingTypes.NOTHING:

--- a/tested/languages/c/templates/values.c
+++ b/tested/languages/c/templates/values.c
@@ -6,34 +6,29 @@
 
 #define format(name, x) "{\"type\": " #name ", \"data\":" #x "}"
 
-// Replace a character with a substring.
-// Not very efficient.
-char* str_replace(const char* stack, char needle, char* with) {
-    const size_t length = strlen(stack);
-    const size_t added = strlen(with);
-    char* result = calloc(length + 1, sizeof(char));
-    size_t totalLength = length;
-
-    size_t j = 0;
-    for (size_t i = 0; i < length; i++) {
-        const char current = stack[i];
-        if (current == needle) {
-            // Enlarge the result.
-            totalLength += added;
-            result = realloc(result, sizeof(char) * (totalLength + 1));
-            for (size_t k = 0; k < added; k++) {
-                result[j + k] = with[k];
+// Escape string characters
+char* escape(char* buffer){
+    int i,j;
+    int l = strlen(buffer) + 1;
+    char esc_char[]= { '\a','\b','\f','\n','\r','\t','\v','\\','\"','\''};
+    char essc_str[]= {  'a', 'b', 'f', 'n', 'r', 't', 'v','\\','\"','\''};
+    char *dest = (char*) calloc(l*2, sizeof(char));
+    char *ptr = dest;
+    for(i=0;i<l;i++){
+        for(j=0; j< 10 ;j++){
+            if( buffer[i]==esc_char[j] ){
+              *ptr++ = '\\';
+              *ptr++ = essc_str[j];
+                 break;
             }
-            j += added;
-        } else {
-            result[j] = current;
-            j++;
+        }
+        if(j >= 10) {
+            *ptr++ = buffer[i];
         }
     }
-
-    return result;
+    *ptr='\0';
+    return dest;
 }
-
 
 void write_bool(FILE* out, bool value) {
     const char* asString = format("boolean", %s);
@@ -44,7 +39,7 @@ void write_char(FILE* out, char value) {
     const char* asString = format("char", "%s");
     char buffer[2];
     sprintf(buffer, "%c", value);
-    char* result = str_replace(buffer, '"', "\\\"");
+    char* result = escape(buffer);
     fprintf(out, asString, result);
     free(result);
 
@@ -117,7 +112,7 @@ void write_ldouble(FILE* out, long double value) {
 
 void write_string(FILE* out, const char* value) {
     const char* asString = format("text", "%s");
-    char* result = str_replace(value, '"', "\\\"");
+    char* result = escape(value);
     fprintf(out, asString, result);
     free(result);
 }

--- a/tested/languages/c/templates/values.c
+++ b/tested/languages/c/templates/values.c
@@ -7,7 +7,7 @@
 #define format(name, x) "{\"type\": " #name ", \"data\":" #x "}"
 
 // Escape string characters
-char* escape(char* buffer){
+char* escape(const char* buffer){
     int i,j;
     int l = strlen(buffer) + 1;
     char esc_char[]= { '\a','\b','\f','\n','\r','\t','\v','\\','\"','\''};

--- a/tested/languages/c/templates/values.c
+++ b/tested/languages/c/templates/values.c
@@ -7,22 +7,23 @@
 #define format(name, x) "{\"type\": " #name ", \"data\":" #x "}"
 
 // Escape string characters
+// Idea: https://stackoverflow.com/questions/3201451/how-to-convert-a-c-string-into-its-escaped-version-in-c
 char* escape(const char* buffer){
     int i,j;
     int l = strlen(buffer) + 1;
-    char esc_char[]= { '\a','\b','\f','\n','\r','\t','\v','\\','\"','\''};
-    char essc_str[]= {  'a', 'b', 'f', 'n', 'r', 't', 'v','\\','\"','\''};
+    char esc_char[]= { '\a','\b','\f','\n','\r','\t','\v','\\','\"'};
+    char essc_str[]= {  'a', 'b', 'f', 'n', 'r', 't', 'v','\\','\"'};
     char *dest = (char*) calloc(l*2, sizeof(char));
     char *ptr = dest;
     for(i=0;i<l;i++){
-        for(j=0; j< 10 ;j++){
+        for(j=0; j< 9 ;j++){
             if( buffer[i]==esc_char[j] ){
               *ptr++ = '\\';
               *ptr++ = essc_str[j];
                  break;
             }
         }
-        if(j >= 10) {
+        if(j >= 9) {
             *ptr++ = buffer[i];
         }
     }
@@ -37,8 +38,7 @@ void write_bool(FILE* out, bool value) {
 
 void write_char(FILE* out, char value) {
     const char* asString = format("char", "%s");
-    char buffer[2];
-    sprintf(buffer, "%c", value);
+    char buffer[2] = {value, '\0'};
     char* result = escape(buffer);
     fprintf(out, asString, result);
     free(result);

--- a/tested/languages/haskell/templates/value.mako
+++ b/tested/languages/haskell/templates/value.mako
@@ -2,6 +2,7 @@
 <%! from tested.datatypes import AdvancedSequenceTypes, AdvancedNumericTypes, AdvancedStringTypes %>\
 <%! from tested.serialisation import as_basic_type %>\
 <%! from tested.utils import get_args %>\
+<%! from json import dumps %>\
 <%page args="value" />\
 <%!
     def escape_char(text):
@@ -13,7 +14,7 @@
 % elif isinstance(value.type, get_args(AdvancedNumericTypes)):
     ${value.data} :: <%include file="declaration.mako" args="tp=value.type" />\
 % elif value.type == AdvancedStringTypes.CHAR:
-    '${escape_char(value.data)}'\
+    '${escape_char(dumps(value.data)[1:-1])}'\
 % else:
     ## Handle the base types
     <% basic = as_basic_type(value) %>\

--- a/tested/languages/haskell/templates/value_basic.mako
+++ b/tested/languages/haskell/templates/value_basic.mako
@@ -1,16 +1,13 @@
 ## Convert a Value to a literal type in Java.
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
+<%! from json import dumps %>\
 <%page args="value" />\
-<%!
-    def escape_string(text):
-        return text.replace('"', '\\"')
-%>\
 % if value.type == BasicNumericTypes.INTEGER:
     ${value.data} :: Int\
 % elif value.type == BasicNumericTypes.RATIONAL:
     ${value.data} :: Double\
 % elif value.type == BasicStringTypes.TEXT:
-    "${escape_string(value.data)}"\
+    ${dumps(value.data)}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     ${str(value.data)}\
 % elif value.type == BasicNothingTypes.NOTHING:

--- a/tested/languages/java/templates/value.mako
+++ b/tested/languages/java/templates/value.mako
@@ -1,6 +1,7 @@
 ## Convert a Value to a literal type in Java.
 <%! from tested.datatypes import AdvancedSequenceTypes, AdvancedNumericTypes, AdvancedStringTypes %>\
 <%! from tested.serialisation import as_basic_type %>\
+<%! from json import dumps %>\
 <%page args="value" />\
 <%!
     def escape_char(text):
@@ -24,7 +25,7 @@
 % elif value.type in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
     new BigDecimal("${value.data}")\
 % elif value.type == AdvancedStringTypes.CHAR:
-    '${escape_char(value.data)}'\
+    '${escape_char(dumps(value.data)[1:-1])}'\
 % else:
     ## Handle the base types
     <% basic = as_basic_type(value) %>\

--- a/tested/languages/java/templates/value_basic.mako
+++ b/tested/languages/java/templates/value_basic.mako
@@ -1,16 +1,13 @@
 ## Convert a Value to a literal type in Java.
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
+<%! from json import dumps %>\
 <%page args="value" />\
-<%!
-    def escape_string(text):
-        return text.replace('"', '\\"')
-%>\
 % if value.type == BasicNumericTypes.INTEGER:
     ${value.data}\
 % elif value.type == BasicNumericTypes.RATIONAL:
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:
-    "${escape_string(value.data)}"\
+    ${dumps(value.data)}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     ${str(value.data).lower()}\
 % elif value.type == BasicNothingTypes.NOTHING:

--- a/tested/languages/javascript/templates/value_basic.mako
+++ b/tested/languages/javascript/templates/value_basic.mako
@@ -1,14 +1,11 @@
 ## Convert a base type literal into Javascript.
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
+<%! from json import dumps %>\
 <%page args="value" />\
-<%!
-    def escape_string(text):
-        return text.replace('"', '\\"')
-%>\
 % if value.type in (BasicNumericTypes.INTEGER, BasicNumericTypes.RATIONAL):
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:
-    "${escape_string(value.data)}"\
+    ${dumps(value.data)}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     ## JavaScript Boolean literals (true, false) are lowercase (pascal case in Python)
     ${str(value.data).lower()}\

--- a/tested/languages/kotlin/templates/value.mako
+++ b/tested/languages/kotlin/templates/value.mako
@@ -1,6 +1,7 @@
 ## Convert a Value to a literal type in Kotlin.
 <%! from tested.datatypes import AdvancedSequenceTypes, AdvancedNumericTypes, AdvancedStringTypes %>\
 <%! from tested.serialisation import as_basic_type %>\
+<%! from json import dumps %>\
 <%page args="value" />\
 <%!
     def escape_char(text):
@@ -14,7 +15,7 @@
 % elif value.type in (AdvancedNumericTypes.DOUBLE_EXTENDED, AdvancedNumericTypes.FIXED_PRECISION):
     BigDecimal("${value.data}")\
 % elif value.type == AdvancedStringTypes.CHAR:
-    '${escape_char(value.data)}'\
+    '${escape_char(dumps(value.data)[1:-1])}'\
 % else:
     ## Handle the base types
     <% basic = as_basic_type(value) %>\

--- a/tested/languages/kotlin/templates/value_basic.mako
+++ b/tested/languages/kotlin/templates/value_basic.mako
@@ -1,16 +1,13 @@
 ## Convert a Value to a literal type in Kotlin.
 <%! from tested.datatypes import BasicNumericTypes, BasicStringTypes, BasicBooleanTypes, BasicNothingTypes, BasicSequenceTypes, BasicObjectTypes  %>\
+<%! from json import dumps %>\
 <%page args="value" />\
-<%!
-    def escape_string(text):
-        return text.replace('"', '\\"')
-%>\
 % if value.type == BasicNumericTypes.INTEGER:
     ${value.data}\
 % elif value.type == BasicNumericTypes.RATIONAL:
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:
-    "${escape_string(value.data)}"\
+    ${dumps(value.data)}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     ${str(value.data).lower()}\
 % elif value.type == BasicNothingTypes.NOTHING:

--- a/tested/languages/python/templates/value_basic.mako
+++ b/tested/languages/python/templates/value_basic.mako
@@ -4,7 +4,7 @@
 % if value.type in (BasicNumericTypes.INTEGER, BasicNumericTypes.RATIONAL):
     ${value.data}\
 % elif value.type == BasicStringTypes.TEXT:
-    ${repr(value.data).replace("\\\\", "\\")}\
+    ${repr(value.data)}\
 % elif value.type == BasicBooleanTypes.BOOLEAN:
     ${str(value.data)}\
 % elif value.type == BasicNothingTypes.NOTHING:

--- a/tested/manual.py
+++ b/tested/manual.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from .configs import DodonaConfig
 from .main import run
 
-exercise_dir = "exercise/objects"
+exercise_dir = "exercise/echo-function"
 
 
 def read_config() -> DodonaConfig:
@@ -27,7 +27,7 @@ def read_config() -> DodonaConfig:
         "source":               Path(exercise_dir, 'solution/correct.java'),
         "judge":                Path('.'),
         "workdir":              Path('workdir'),
-        "plan_name":            "no-test.yaml",
+        "plan_name":            "one-escape.tson",
         "options":              {
             "parallel":       True,
             "mode":           "batch",

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -152,7 +152,7 @@ def test_parse_value_text():
 def test_parse_value_text_cast():
     parsed = parser.parse_value(r'"this\nis\na\nstring" :: text')
     assert parsed.type == BasicStringTypes.TEXT
-    assert parsed.data == r"this\nis\na\nstring"
+    assert parsed.data == "this\nis\na\nstring"
 
 
 def test_parse_value_char():

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -59,6 +59,14 @@ def test_io_function_exercise(language: str, tmp_path: Path, pytestconfig):
     assert updates.find_status_enum() == ["correct"]
 
 
+@pytest.mark.parametrize("language", ALL_LANGUAGES)
+def test_io_function_escape_exercise(language: str, tmp_path: Path, pytestconfig):
+    conf = configuration(pytestconfig, "echo-function", language, tmp_path, "one-escape.tson", "correct")
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"]
+
+
 @mark_haskell
 @pytest.mark.parametrize("language", ("haskell", "runhaskell"))
 def test_io_function_exercise_haskell_io(language: str, tmp_path: Path, pytestconfig):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,7 +210,7 @@ def test_template_escaped_string_code_block_markdown(lang: str, prompt: str):
 "alpha\"beta\tname"
 ```"""
     instance = create_description_instance(template, programming_language=lang, is_html=False)
-    expected_str = r"'alpha\"beta\tname'" if lang == "python" else r'"alpha\\"beta\tname"'
+    expected_str = "'alpha\"beta\\tname'" if lang == "python" else r'"alpha\"beta\tname"'
     expected = f"""```console?lang={lang}&prompt={prompt}
 {expected_str}
 ```"""


### PR DESCRIPTION
close #172 
Use `json.dumps` to escape string which are passed by the generator, except for python which uses `repr`