### PR TITLE
Update description generator variables and functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install GHC 8.10
         uses: actions/setup-haskell@v1.1.4
         with:
-          ghc-version: '8.10.3'
+          ghc-version: '8.10.4'
           cabal-version: '3.4'
       - uses: actions/cache@v2
         name: Cache cabal
@@ -40,10 +40,9 @@ jobs:
             ~/.cabal
             ~/.ghc
             dist-newstyle
-          key: ${{ runner.os }}-cabalghc-20210330
+          key: ${{ runner.os }}-ghc-8.10.4-20210330
           restore-keys: |
-            ${{ runner.os }}-cabalghc-
-            ${{ runner.os }}-cabal-
+            ${{ runner.os }}-ghc-8.10.4-
       - name: Install Haskell dependencies
         run: cabal v1-install aeson
       - name: Use node 14

--- a/descriptions/demo.md.mako
+++ b/descriptions/demo.md.mako
@@ -1,3 +1,3 @@
-The function ${function_name("characterize_string")} takes one
-${type_name("text")} as argument and returns a ${natural_type_name("sequence")}
-of characters of type ${type_name(("sequence", "char"))}.
+The function ${function("characterize_string")} takes one
+${datatype("text")} as argument and returns a ${datatype_common("sequence")}
+of characters of type ${datatype(("sequence", "char"))}.

--- a/descriptions/erfgenaam.md.mako
+++ b/descriptions/erfgenaam.md.mako
@@ -43,7 +43,7 @@ en de uiteindelijke erfgenaam als laatste in de ${lijst}.
 Gebruik de volgnummers waarmee de kinderen in de ${lijst}
 genummerd werden als elementen in de ${lijst}.
 
-% if language == 'java':
+% if programming_language_for_condition == 'java':
 De functies moeten statisch gedefinieerd worden in de klasse ${namespace}.
 % endif
 

--- a/descriptions/erfgenaam.md.mako
+++ b/descriptions/erfgenaam.md.mako
@@ -31,12 +31,12 @@ We beginnen in wijzerzin af te tellen vanaf kind nummer $1$, waarbij elk $n$-de 
 Nadat $k-1$ kinderen uit de cirkel verwijderd werden, wordt verder geteld in tegenwijzerzin.
 De cirkel wordt steeds kleiner en kleiner en het laatste kind dat overblijft wordt de erfgenaam van de boer.
 
-<% lijst = natural_type_name("list") %>\
+<% lijst = datatype_common("list") %>\
 
-Schrijf een functie ${function_name("heir")},
-waaraan de waarden $k$ en $n$, van het type ${type_name("integer")},
+Schrijf een functie ${function("heir")},
+waaraan de waarden $k$ en $n$, van het type ${datatype("integer")},
 moeten doorgegeven worden, waarbij je er mag van uitgaan dat $k >= 2$.
-De functie moet een ${lijst}, van het type ${type_name(("list", "integer"))}
+De functie moet een ${lijst}, van het type ${datatype(("list", "integer"))}
 teruggeven die de volgorde aangeeft waarin de kinderen uit de cirkel verwijderd werden.
 Het eerst verwijderde kind staat daarbij als eerste in de ${lijst},
 en de uiteindelijke erfgenaam als laatste in de ${lijst}.

--- a/descriptions/erfgenaam.md.mako
+++ b/descriptions/erfgenaam.md.mako
@@ -43,7 +43,7 @@ en de uiteindelijke erfgenaam als laatste in de ${lijst}.
 Gebruik de volgnummers waarmee de kinderen in de ${lijst}
 genummerd werden als elementen in de ${lijst}.
 
-% if programming_language_for_condition == 'java':
+% if programming_language_raw == 'java':
 De functies moeten statisch gedefinieerd worden in de klasse ${namespace}.
 % endif
 

--- a/descriptions/spoorhekcodering.html.mako
+++ b/descriptions/spoorhekcodering.html.mako
@@ -79,13 +79,13 @@
     </li>
 </ul>
 
-% if language == 'java':
-<p> The functions must be static declared in the class ${namespace_html}.</p>
+% if programming_language_for_condition == 'java':
+<p> The functions must be static declared in the class ${namespace}.</p>
 % endif
 
 <h3>Example</h3>
 
-<div class="highlighter-rouge language-${language}">
+<div class="highlighter-rouge language-${programming_language_for_condition}">
 <pre class="highlight"><code class="color tested code" id="code">\
 > encode("And now for something completely different.",
          1)

--- a/descriptions/spoorhekcodering.html.mako
+++ b/descriptions/spoorhekcodering.html.mako
@@ -79,7 +79,7 @@
     </li>
 </ul>
 
-% if programming_language_for_condition == 'java':
+% if programming_language_raw == 'java':
 <p> The functions must be static declared in the class ${namespace}.</p>
 % endif
 

--- a/descriptions/spoorhekcodering.html.mako
+++ b/descriptions/spoorhekcodering.html.mako
@@ -62,20 +62,20 @@
 
 <h3>Assignment</h3>
 <ul>
-    <li>Write a function <code>${function_name("encode")}</code> that takes two arguments:
+    <li>Write a function <code>${function("encode")}</code> that takes two arguments:
         <ol>
             <li>a text string (${type_name("text")}) and</li>
-            <li>the number (${type_name("integer")}) of rails used in the rail fence cipher.</li>
+            <li>the number (${datatype("integer")}) of rails used in the rail fence cipher.</li>
         </ol>
-        The function must return a string (${type_name("text")}) containing the encoded message of the given text,
+        The function must return a string (${datatype("text")}) containing the encoded message of the given text,
         according to the rail fence cipher with the given number of rails.
     </li>
-    <li>Write a function <code>${function_name("decode")}</code> that takes two arguments:
+    <li>Write a function <code>${function("decode")}</code> that takes two arguments:
         <ol>
-            <li> a text (${type_name("text")}) encoded according to the rail fence cipher and</li>
-            <li>the number (${type_name("integer")}) of rails used in the coding scheme.</li>
+            <li> a text (${datatype("text")}) encoded according to the rail fence cipher and</li>
+            <li>the number (${datatype("integer")}) of rails used in the coding scheme.</li>
         </ol>
-        The function must return a string (${type_name("text")}) containing the original text after decoding.
+        The function must return a string (${datatype("text")}) containing the original text after decoding.
     </li>
 </ul>
 

--- a/tested/description_instance.py
+++ b/tested/description_instance.py
@@ -165,21 +165,21 @@ def create_description_instance_from_template(template: Template,
         return description_generator.get_natural_type_name(type_name, bundle,
                                                            plural, is_html)
 
+    def get_variable(var_name: str, is_global: bool = True):
+        if is_global:
+            return description_generator.get_global_variable_name(var_name, is_html)
+        return description_generator.get_variable_name(var_name, is_html)
+
     namespace = language.conventionalize_namespace(namespace)
     if is_html:
         namespace = html.escape(namespace)
 
     return template.render(
-        function_name=partial(description_generator.get_function_name,
-                              is_html=is_html),
-        property_name=partial(description_generator.get_property_name,
-                              is_html=is_html),
-        var_name=partial(description_generator.get_variable_name,
-                         is_html=is_html),
-        global_var_name=partial(description_generator.get_global_variable_name,
-                                is_html=is_html),
-        natural_type_name=get_natural_type_name,
-        type_name=get_type_name,
+        function=partial(description_generator.get_function_name, is_html=is_html),
+        property=partial(description_generator.get_property_name, is_html=is_html),
+        variable=get_variable,
+        datatype_common=get_natural_type_name,
+        datatype=get_type_name,
         statement=partial(description_generator.get_code, bundle=bundle,
                           is_html=is_html, statement=True),
         expression=partial(description_generator.get_code, bundle=bundle,

--- a/tested/description_instance.py
+++ b/tested/description_instance.py
@@ -18,6 +18,11 @@ from tested.languages import get_language, language_exists
 open_brackets = ('(', '[', '{')
 close_brackets = {')': '(', ']': '[', '}': '{'}
 
+natural_languages = {
+    "en": "English",
+    "nl": "Nederlands"
+}
+
 
 def _mako_uncomment(m: re.Match) -> str:
     result = f"${{{repr(m.group(1))}}}"
@@ -154,6 +159,14 @@ def create_description_instance_from_template(template: Template,
         return description_generator.get_type_name(args, bundle, custom_type_map,
                                                    is_html=is_html)
 
+    def get_natural_type_name(type_name: str, plural: bool = False):
+        return description_generator.get_natural_type_name(type_name, bundle,
+                                                           plural, is_html)
+
+    namespace = language.conventionalize_namespace(namespace)
+    if is_html:
+        namespace = html.escape(namespace)
+
     return template.render(
         function_name=partial(description_generator.get_function_name,
                               is_html=is_html),
@@ -163,18 +176,20 @@ def create_description_instance_from_template(template: Template,
                          is_html=is_html),
         global_var_name=partial(description_generator.get_global_variable_name,
                                 is_html=is_html),
-        natural_type_name=partial(description_generator.get_natural_type_name,
-                                  bundle=bundle, is_html=is_html),
+        natural_type_name=get_natural_type_name,
         type_name=get_type_name,
         statement=partial(description_generator.get_code, bundle=bundle,
                           is_html=is_html, statement=True),
         expression=partial(description_generator.get_code, bundle=bundle,
                            is_html=is_html, statement=False),
         prompt=description_generator.get_prompt(is_html=is_html),
-        language_html=description_generator.get_prompt_language(is_html=True),
-        language=description_generator.get_prompt_language(is_html=False),
-        namespace_html=html.escape(language.conventionalize_namespace(namespace)),
-        namespace=language.conventionalize_namespace(namespace)
+        programming_language=description_generator.get_prompt_language(
+            is_html=is_html),
+        programming_language_for_condition=
+        description_generator.get_prompt_language(is_html=False),
+        namespace=language.conventionalize_namespace(namespace),
+        natural_language=natural_languages.get(natural_language, natural_language),
+        natural_language_iso639=natural_language
     )
 
 

--- a/tested/description_instance.py
+++ b/tested/description_instance.py
@@ -114,13 +114,15 @@ def prepare_template(template: str, is_html: bool = True) -> Template:
         if is_html:
             mako_template.extend(groups[0])
         else:
-            mako_template.extend("```console?lang=${language}&prompt=${prompt}\n")
+            mako_template.extend(
+                "```console?lang=${programming_language}&prompt=${prompt}\n")
         mako_template.extend(_analyse_body(groups[body_index]))
         mako_template.extend(groups[-1])
 
     mako_template.extend(
         regex_comment_mako.sub(_mako_uncomment, template[last_end:]))
-    return Template(''.join(mako_template), cache_enabled=False)
+    mako_template = ''.join(mako_template)
+    return Template(mako_template, cache_enabled=False)
 
 
 def create_description_instance_from_template(template: Template,

--- a/tested/description_instance.py
+++ b/tested/description_instance.py
@@ -115,7 +115,7 @@ def prepare_template(template: str, is_html: bool = True) -> Template:
             mako_template.extend(groups[0])
         else:
             mako_template.extend(
-                "```console?lang=${programming_language}&prompt=${prompt}\n")
+                "```console?lang=${programming_language_raw}&prompt=${prompt}\n")
         mako_template.extend(_analyse_body(groups[body_index]))
         mako_template.extend(groups[-1])
 
@@ -187,7 +187,7 @@ def create_description_instance_from_template(template: Template,
         prompt=description_generator.get_prompt(is_html=is_html),
         programming_language=description_generator.get_prompt_language(
             is_html=is_html),
-        programming_language_for_condition=
+        programming_language_raw=
         description_generator.get_prompt_language(is_html=False),
         namespace=language.conventionalize_namespace(namespace),
         natural_language=natural_languages.get(natural_language, natural_language),

--- a/tested/generation/types.json
+++ b/tested/generation/types.json
@@ -36,23 +36,45 @@
   "inner": {
   },
   "natural": {
-    "en": {
-      "text": "text",
-      "sequence": "sequence",
-      "set": "set",
-      "map": "map",
-      "array": "array",
-      "list": "list",
-      "tuple": "tuple"
+    "singular": {
+      "en": {
+        "text": "text",
+        "sequence": "sequence",
+        "set": "set",
+        "map": "map",
+        "array": "array",
+        "list": "list",
+        "tuple": "tuple"
+      },
+      "nl": {
+        "text": "tekst",
+        "sequence": "sequentie",
+        "set": "verzameling",
+        "map": "afbeelding",
+        "array": "array",
+        "list": "lijst",
+        "tuple": "tuple"
+      }
     },
-    "nl": {
-      "text": "tekst",
-      "sequence": "sequentie",
-      "set": "verzameling",
-      "map": "afbeelding",
-      "array": "array",
-      "list": "lijst",
-      "tuple": "tupel"
+    "plural": {
+      "en": {
+        "text": "texts",
+        "sequence": "sequences",
+        "set": "sets",
+        "map": "maps",
+        "array": "arrays",
+        "list": "lists",
+        "tuple": "tuples"
+      },
+      "nl": {
+        "text": "teksten",
+        "sequence": "sequenties",
+        "set": "verzamelingen",
+        "map": "afbeeldingen",
+        "array": "arrays",
+        "list": "lijsten",
+        "tuple": "tuples"
+      }
     }
   }
 }

--- a/tested/languages/bash/types.json
+++ b/tested/languages/bash/types.json
@@ -35,23 +35,21 @@
   "any": "any",
   "inner": {},
   "natural": {
-    "en": {
-      "text": "text",
-      "sequence": "sequence",
-      "set": "set",
-      "map": "map",
-      "array": "array",
-      "list": "list",
-      "tuple": "tuple"
+    "singular": {
+      "en": {
+        "text": "text"
+      },
+      "nl": {
+        "text": "tekst"
+      }
     },
-    "nl": {
-      "text": "tekst",
-      "sequence": "sequentie",
-      "set": "verzameling",
-      "map": "afbeelding",
-      "array": "array",
-      "list": "lijst",
-      "tuple": "tupel"
+    "plural": {
+      "en": {
+        "text": "texts"
+      },
+      "nl": {
+        "text": "teksten"
+      }
     }
   }
 }

--- a/tested/languages/c/types.json
+++ b/tested/languages/c/types.json
@@ -24,11 +24,21 @@
   "inner": {
   },
   "natural": {
-    "en": {
-      "text": "string"
+    "singular": {
+      "en": {
+        "text": "string"
+      },
+      "nl": {
+        "text": "string"
+      }
     },
-    "nl": {
-      "text": "string"
+    "plural": {
+      "en": {
+        "text": "strings"
+      },
+      "nl": {
+        "text": "strings"
+      }
     }
   }
 }

--- a/tested/languages/description_generator.py
+++ b/tested/languages/description_generator.py
@@ -125,32 +125,32 @@ class DescriptionGenerator:
             else:
                 raise ValueError(f"Type {main_type} expects only one subtype")
         if is_html and not recursive_call:
-            return f"<code>{html.escape(type_name)}</code>"
-        return f"`{type_name}`" if not recursive_call else type_name
+            return html.escape(type_name)
+        return type_name
 
     def get_function_name(self, name: str, is_html: bool = True) -> str:
         function_name = self.language.conventionalize_function(name)
         if is_html:
-            return f"<code>{html.escape(function_name)}</code>"
-        return f"`{function_name}`"
+            return html.escape(function_name)
+        return function_name
 
     def get_property_name(self, name: str, is_html: bool = True) -> str:
         name = self.language.conventionalize_property(name)
         if is_html:
-            return f"<code>{html.escape(name)}</code>"
-        return f"`{name}`"
+            return html.escape(name)
+        return name
 
     def get_variable_name(self, name: str, is_html: bool = True) -> str:
         name = self.language.conventionalize_identifier(name)
         if is_html:
-            return f"<code>{html.escape(name)}</code>"
-        return f"`{name}`"
+            return html.escape(name)
+        return name
 
     def get_global_variable_name(self, name: str, is_html: bool = True) -> str:
         name = self.language.conventionalize_global_identifier(name)
         if is_html:
-            return f"<code>{html.escape(name)}</code>"
-        return f"`{name}`"
+            return html.escape(name)
+        return name
 
     def get_code(self, stmt: str, bundle: Bundle, statement: bool = False,
                  is_html: bool = True) -> str:

--- a/tested/languages/description_generator.py
+++ b/tested/languages/description_generator.py
@@ -50,9 +50,10 @@ class DescriptionGenerator:
                                         stripall=True)
 
     def get_natural_type_name(self, type_name: str, bundle: Bundle,
-                              is_html: bool = True) -> str:
+                              plural: bool = False, is_html: bool = True) -> str:
         try:
-            value = self.types["natural"][bundle.config.natural_language][type_name]
+            group = self.types["natural"]["plural" if plural else "singular"]
+            value = group[bundle.config.natural_language][type_name]
         except KeyError:
             value = type_name
         return html.escape(value) if is_html else value

--- a/tested/languages/haskell/types.json
+++ b/tested/languages/haskell/types.json
@@ -40,19 +40,37 @@
   "inner": {
   },
   "natural": {
-    "en": {
-      "text": "string",
-      "sequence": "list",
-      "set": "set",
-      "list": "list",
-      "tuple": "tuple"
+    "singular": {
+      "en": {
+        "text": "string",
+        "sequence": "list",
+        "set": "set",
+        "list": "list",
+        "tuple": "tuple"
+      },
+      "nl": {
+        "text": "string",
+        "sequence": "lijst",
+        "set": "verzameling",
+        "list": "lijst",
+        "tuple": "tuple"
+      }
     },
-    "nl": {
-      "text": "string",
-      "sequence": "lijst",
-      "set": "verzameling",
-      "list": "lijst",
-      "tuple": "tuple"
+    "plural": {
+      "en": {
+        "text": "strings",
+        "sequence": "lists",
+        "set": "sets",
+        "list": "lists",
+        "tuple": "tuples"
+      },
+      "nl": {
+        "text": "strings",
+        "sequence": "lijsten",
+        "set": "verzamelingen",
+        "list": "lijsten",
+        "tuple": "tuples"
+      }
     }
   }
 }

--- a/tested/languages/java/types.json
+++ b/tested/languages/java/types.json
@@ -52,21 +52,41 @@
     "int64": "Long"
   },
   "natural": {
-    "en": {
-      "text": "string",
-      "sequence": "list",
-      "set": "set",
-      "map": "map",
-      "array": "array",
-      "list": "list"
+    "singular": {
+      "en": {
+        "text": "string",
+        "sequence": "list",
+        "set": "set",
+        "map": "map",
+        "array": "array",
+        "list": "list"
+      },
+      "nl": {
+        "text": "string",
+        "sequence": "lijst",
+        "set": "verzameling",
+        "map": "map",
+        "array": "array",
+        "list": "lijst"
+      }
     },
-    "nl": {
-      "text": "string",
-      "sequence": "lijst",
-      "set": "verzameling",
-      "map": "map",
-      "array": "array",
-      "list": "lijst"
+    "plural": {
+      "en": {
+        "text": "strings",
+        "sequence": "lists",
+        "set": "sets",
+        "map": "maps",
+        "array": "arrays",
+        "list": "lists"
+      },
+      "nl": {
+        "text": "strings",
+        "sequence": "lijsten",
+        "set": "verzamelingen",
+        "map": "maps",
+        "array": "arrays",
+        "list": "lijsten"
+      }
     }
   }
 }

--- a/tested/languages/javascript/types.json
+++ b/tested/languages/javascript/types.json
@@ -35,21 +35,41 @@
   "inner": {
   },
   "natural": {
-    "en": {
-      "text": "string",
-      "sequence": "array",
-      "set": "set",
-      "map": "object",
-      "array": "array",
-      "list": "array"
+    "singular": {
+      "en": {
+        "text": "string",
+        "sequence": "array",
+        "set": "set",
+        "map": "object",
+        "array": "array",
+        "list": "array"
+      },
+      "nl": {
+        "text": "string",
+        "sequence": "array",
+        "set": "verzameling",
+        "map": "object",
+        "array": "array",
+        "list": "array"
+      }
     },
-    "nl": {
-      "text": "string",
-      "sequence": "array",
-      "set": "verzameling",
-      "map": "object",
-      "array": "array",
-      "list": "array"
+    "plural": {
+      "en": {
+        "text": "strings",
+        "sequence": "arrays",
+        "set": "sets",
+        "map": "objects",
+        "array": "arrays",
+        "list": "arrays"
+      },
+      "nl": {
+        "text": "strings",
+        "sequence": "arrays",
+        "set": "verzamelingen",
+        "map": "objects",
+        "array": "arrays",
+        "list": "arrays"
+      }
     }
   }
 }

--- a/tested/languages/kotlin/types.json
+++ b/tested/languages/kotlin/types.json
@@ -35,21 +35,41 @@
   "inner": {
   },
   "natural": {
-    "en": {
-      "text": "string",
-      "sequence": "list",
-      "set": "set",
-      "map": "map",
-      "array": "array",
-      "list": "list"
+    "singular": {
+      "en": {
+        "text": "string",
+        "sequence": "list",
+        "set": "set",
+        "map": "map",
+        "array": "array",
+        "list": "list"
+      },
+      "nl": {
+        "text": "string",
+        "sequence": "lijst",
+        "set": "verzameling",
+        "map": "map",
+        "array": "array",
+        "list": "lijst"
+      }
     },
-    "nl": {
-      "text": "string",
-      "sequence": "lijst",
-      "set": "verzameling",
-      "map": "map",
-      "array": "array",
-      "list": "lijst"
+    "plural": {
+      "en": {
+        "text": "strings",
+        "sequence": "lists",
+        "set": "sets",
+        "map": "maps",
+        "array": "arrays",
+        "list": "lists"
+      },
+      "nl": {
+        "text": "strings",
+        "sequence": "lijsten",
+        "set": "verzamelingen",
+        "map": "maps",
+        "array": "arrays",
+        "list": "lijsten"
+      }
     }
   }
 }

--- a/tested/languages/python/types.json
+++ b/tested/languages/python/types.json
@@ -36,21 +36,41 @@
   "inner": {
   },
   "natural": {
-    "en": {
-      "text": "string",
-      "sequence": "list",
-      "set": "set",
-      "map": "dictionary",
-      "list": "list",
-      "tuple": "tuple"
+    "singular": {
+      "en": {
+        "text": "string",
+        "sequence": "list",
+        "set": "set",
+        "map": "dictionary",
+        "list": "list",
+        "tuple": "tuple"
+      },
+      "nl": {
+        "text": "string",
+        "sequence": "lijst",
+        "set": "verzameling",
+        "map": "dictionary",
+        "list": "lijst",
+        "tuple": "tuple"
+      }
     },
-    "nl": {
-      "text": "string",
-      "sequence": "lijst",
-      "set": "verzameling",
-      "map": "dictionary",
-      "list": "lijst",
-      "tuple": "tuple"
+    "plural": {
+      "en": {
+        "text": "strings",
+        "sequence": "lists",
+        "set": "sets",
+        "map": "dictionaries",
+        "list": "lists",
+        "tuple": "tuples"
+      },
+      "nl": {
+        "text": "strings",
+        "sequence": "lijsten",
+        "set": "verzamelingen",
+        "map": "dictionaries",
+        "list": "lijsten",
+        "tuple": "tuples"
+      }
     }
   }
 }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,9 +53,9 @@ def test_limit_output_no_limit():
     ("runhaskell", "thisIsAFunctionName")
 ])
 def test_template_function_name(lang: str, expected: str):
-    template = '${function_name("this_is_a_function_name")}'
+    template = '${function("this_is_a_function_name")}'
     instance = create_description_instance(template, programming_language=lang, is_html=False)
-    assert instance == f"`{expected}`"
+    assert instance == f"{expected}"
 
 
 @pytest.mark.parametrize(("lang", "tested_type", "expected"), [
@@ -81,9 +81,9 @@ def test_template_function_name(lang: str, expected: str):
     ("haskell", '("tuple", [("sequence", "rational"), "text"])', "([Double], String)"),
 ])
 def test_template_type_name(lang: str, tested_type: Any, expected: str):
-    template = f"""${'{'}type_name({tested_type}){'}'}"""
+    template = f"""${'{'}datatype({tested_type}){'}'}"""
     instance = create_description_instance(template, programming_language=lang, is_html=False)
-    assert instance == f"`{expected}`"
+    assert instance == f"{expected}"
 
 
 @pytest.mark.parametrize(("lang", "tested_type", "expected"), [
@@ -99,7 +99,7 @@ def test_template_type_name(lang: str, tested_type: Any, expected: str):
     ("haskell", "'sequence'", "list"), ("haskell", "'list'", "list"),
 ])
 def test_template_natural_type_name(lang: str, tested_type: Any, expected: str):
-    template = f"""${{natural_type_name({tested_type})}}"""
+    template = f"""${{datatype_common({tested_type})}}"""
     instance = create_description_instance(template, programming_language=lang, is_html=False)
     assert instance == f"{expected}"
 
@@ -117,15 +117,15 @@ def test_template_natural_type_name(lang: str, tested_type: Any, expected: str):
     ("haskell", "'sequence'", "lijst"), ("haskell", "'list'", "lijst"),
 ])
 def test_template_natural_type_name_nl(lang: str, tested_type: Any, expected: str):
-    template = f"""${{natural_type_name({tested_type})}}"""
+    template = f"""${{datatype_common({tested_type})}}"""
     instance = create_description_instance(template, programming_language=lang, is_html=False, natural_language="nl")
     assert instance == f"{expected}"
 
 
 def test_template_type_name_override():
-    template = """${type_name("integer", {"java": {"integer": "long"}})}"""
+    template = """${datatype("integer", {"java": {"integer": "long"}})}"""
     instance = create_description_instance(template, programming_language="java", is_html=False)
-    assert instance == "`long`"
+    assert instance == "long"
 
 
 @pytest.mark.parametrize(("lang", "prompt"), [


### PR DESCRIPTION
Apply some suggestions of @pdawyndt for the template descriptions.

1. Add _plural_ forms for the natural type names.
2. Remove the constant `namespace_html`.
3. `namespace` will be adopted to the Markdown/HTML Context
4. Remove the constant `language_html`.
5. `language` is renamed to `programming_language` and will be adopted to the Markdown/HTML Context.
6. `programming_language_for_condition` contains always the unescaped programming language string.
7. The function `natural_type_name` is extended with a second parameter `plural` with default value `false`.
8. Add the constant `natural_language` contains the natural name of the natural language, with the `iso639-1` code as fallback.
9. Add the constant `natural_language_iso639` contains the `iso639-1` language code for the natural language.