### PR TITLE
Update DSL statement parser

### DIFF
--- a/tested/dsl/statement.py
+++ b/tested/dsl/statement.py
@@ -1,6 +1,6 @@
 from ast import literal_eval
 from os.path import join, dirname, realpath
-from typing import Optional, Union, List, get_args
+from typing import Optional, Union, List, get_args, Tuple
 
 from lark import Lark, Tree, Token, UnexpectedToken
 
@@ -33,15 +33,17 @@ class ParseError(Exception):
 class Parser:
     def __init__(self, grammar_file: Optional[str] = None):
         if not grammar_file:
-            grammar_file = join(dirname(realpath(__file__)), "grammar.lark")
+            grammar_file = join(dirname(realpath(__file__)), "tested.lark")
         self.grammar_file = grammar_file
-        self.parser = Lark.open(grammar_file, start=['stmt', 'return'],
-                                lexer='standard')
+        self.parser = Lark.open(grammar_file, start=['statements', 'return'],
+                                lexer='standard', parser='lalr')
 
-    def analyse_arguments(self, tree: Tree) -> List[Expression]:
+    def analyse_arguments(self, tree: Tree,
+                          allow_functions: bool = True) -> List[Expression]:
         if tree.data != 'args':
             raise ParseError("Function expect argument list")
-        return [self.analyse_expression(arg, True) for arg in tree.children]
+        return [self.analyse_expression(arg, allow_functions)
+                for arg in tree.children]
 
     def analyse_assign(self, tree: Tree) -> Assignment:
         # Determine indices
@@ -104,14 +106,11 @@ class Parser:
         return expression
 
     def analyse_constructor(self, tree: Tree) -> FunctionCall:
-        # Find constructor name
-        namespace, constr_name = self.analyse_namespace(tree.children[0])
-        # Analyse arguments
-        args = self.analyse_arguments(tree.children[1])
-        return FunctionCall(type=FunctionType.CONSTRUCTOR,
-                            name=constr_name,
-                            namespace=namespace,
-                            arguments=args)
+        # Analyse constructor function
+        function = self.analyse_function(tree.children[0])
+        # Update function type
+        function.type = FunctionType.CONSTRUCTOR
+        return function
 
     def analyse_dict(self, tree: Tree,
                      allow_functions: bool = True) -> List[ObjectKeyValuePair]:
@@ -147,24 +146,24 @@ class Parser:
             return BooleanType(type=BasicBooleanTypes.BOOLEAN, data=True)
         elif token.type == 'FALSE':
             return BooleanType(type=BasicBooleanTypes.BOOLEAN, data=False)
+        elif token.type == 'NULL':
+            return NothingType(type=BasicNothingTypes.NOTHING)
+        elif token.type == 'UNDEFINED':
+            return NothingType(type=AdvancedNothingTypes.UNDEFINED)
         raise ParseError("Invalid value token")
 
     def analyse_expression_tree(self, tree: Tree,
                                 allow_functions: bool = True) -> Expression:
-        if tree.data == 'null':
-            nothing_type = (BasicNothingTypes.NOTHING
-                            if tree.children[0].type == "NULL"
-                            else AdvancedNothingTypes.UNDEFINED)
-            return NothingType(type=nothing_type)
-        elif tree.data in ('list', 'set', 'tuple'):
+        if tree.data in ('list', 'set', 'tuple'):
+            if tree.data == 'set':
+                tree.children = [Tree(data="args", children=tree.children)]
+            content = self.analyse_arguments(tree.children[0],
+                                             allow_functions=allow_functions)
             return SequenceType(type=default_sequence_type_map[tree.data],
-                                data=[
-                                    self.analyse_expression(t, allow_functions)
-                                    for t in tree.children
-                                ])
+                                data=content)
         elif tree.data == 'value_cast':
             return self.analyse_cast(tree)
-        elif tree.data == 'fun':
+        elif tree.data == 'function':
             if allow_functions:
                 return self.analyse_function(tree)
             else:
@@ -193,7 +192,7 @@ class Parser:
         # Find function name
         namespace, fun_name = self.analyse_namespace(tree.children[0])
         # Analyse arguments
-        args = self.analyse_arguments(tree.children[1])
+        args = self.analyse_arguments(tree.children[1], allow_functions=True)
         return FunctionCall(type=FunctionType.FUNCTION,
                             name=fun_name,
                             namespace=namespace,
@@ -206,7 +205,7 @@ class Parser:
 
     def analyse_property(self, tree: Tree) -> FunctionCall:
         # Find namespace name
-        _a, namespace = self.analyse_namespace(tree.children[0])
+        namespace = self.analyse_expression(tree.children[0])
         # Find property name
         prop_name = self.analyse_name(tree.children[1])
         return FunctionCall(name=prop_name,
@@ -219,15 +218,12 @@ class Parser:
             raise ParseError("Invalid variable/function name")
         return token.value
 
-    def analyse_namespace(self, tree: Union[Tree, Token]):
-        if isinstance(tree, Token):
-            return None, self.analyse_expression_token(tree)
-        if tree.data != 'name':
-            return None, self.analyse_expression_tree(tree)
-        if len(tree.children) == 1:
-            return None, self.analyse_name(tree.children[0])
-        return (self.analyse_expression(tree.children[0], allow_functions=True),
-                self.analyse_name(tree.children[1]))
+    def analyse_namespace(self, tree: Union[Tree, Token]
+                          ) -> Tuple[Optional[Expression], str]:
+        expression = self.analyse_expression(tree, allow_functions=True)
+        if isinstance(expression, str):
+            return None, expression
+        return expression.namespace, expression.name
 
     # noinspection PyMethodMayBeStatic
     def analyse_type_token(self, token: Token,
@@ -241,8 +237,8 @@ class Parser:
 
     def parse_statement(self, statement: str) -> Statement:
         try:
-            parse_tree = self.parser.parse(statement, start='stmt')
-            if isinstance(parse_tree, Tree) and parse_tree.data == 'assign':
+            parse_tree = self.parser.parse(statement, start='statements')
+            if isinstance(parse_tree, Tree) and parse_tree.data == 'assignment':
                 return self.analyse_assign(parse_tree)
             return self.analyse_expression(parse_tree, True)
         except UnexpectedToken as e:

--- a/tested/dsl/statement.py
+++ b/tested/dsl/statement.py
@@ -201,7 +201,7 @@ class Parser:
     # noinspection PyMethodMayBeStatic
     def analyse_global_variable(self, tree: Tree) -> FunctionCall:
         return FunctionCall(type=FunctionType.PROPERTY,
-                            name=self.analyse_name(tree.children[1]))
+                            name=self.analyse_name(tree.children[0]))
 
     def analyse_property(self, tree: Tree) -> FunctionCall:
         # Find namespace name

--- a/tested/dsl/statement.py
+++ b/tested/dsl/statement.py
@@ -35,6 +35,8 @@ class Parser:
         if not grammar_file:
             grammar_file = join(dirname(realpath(__file__)), "tested.lark")
         self.grammar_file = grammar_file
+        # Don't modify the parser, the parser must be 'lalr' for fast parsing
+        # Modify the grammar instead to be unambiguous
         self.parser = Lark.open(grammar_file, start=['statements', 'return'],
                                 lexer='standard', parser='lalr')
 

--- a/tested/dsl/tested.lark
+++ b/tested/dsl/tested.lark
@@ -99,12 +99,14 @@ value_cast: value_raw "::" datatype
 
 _property: "." CNAME
 
-property: "(" expression ")" _property
-    | function _property
-    | property _property
-    | value _property
-    | variable _property
-    | global_variable _property
+?internal_expression: "(" expression ")"
+    | function
+    | property
+    | value_raw
+    | variable
+    | global_variable
+
+property: internal_expression _property
 
 
 args: [expression ("," expression)*]

--- a/tested/dsl/tested.lark
+++ b/tested/dsl/tested.lark
@@ -119,6 +119,7 @@ function: name arguments
 constructor: "new" function
 
 ?expression: "(" expression ")"
+    | "(" constructor ")"
     | global_variable
     | variable
     | value

--- a/tested/dsl/tested.lark
+++ b/tested/dsl/tested.lark
@@ -99,8 +99,7 @@ value_cast: value_raw "::" datatype
 
 _property: "." CNAME
 
-property: "(" constructor ")" _property
-    | "(" expression ")" _property
+property: "(" expression ")" _property
     | function _property
     | property _property
     | value _property
@@ -119,7 +118,6 @@ function: name arguments
 constructor: "new" function
 
 ?expression: "(" expression ")"
-    | "(" constructor ")"
     | global_variable
     | variable
     | value

--- a/tested/dsl/tested.lark
+++ b/tested/dsl/tested.lark
@@ -1,3 +1,10 @@
+%import common.CNAME
+%import common.ESCAPED_STRING
+%import common.SIGNED_INT
+%import common.SIGNED_FLOAT
+%import common.WS
+%ignore WS
+
 INTEGER: "integer"
 RATIONAL: "rational"
 CHAR: "char"
@@ -23,6 +30,10 @@ DOUBLE_EXTENDED: "extended"
 FIXED_PRECISION: "fixed"
 ARRAY: "array"
 LIST: "list"
+NULL: "null"
+UNDEFINED: "undefined"
+TRUE: "true"
+FALSE: "false"
 
 ?collections: SEQUENCE
             | SET
@@ -55,10 +66,19 @@ LIST: "list"
 ?assign_datatype: datatype
                 | CNAME
 
-TRUE: "true"
-FALSE: "false"
+?null: NULL
+    | UNDEFINED
+
 ?boolean: TRUE
         | FALSE
+
+?string: ESCAPED_STRING
+
+dict: "{" [dict_pair ("," dict_pair)*] "}"
+list: "[" args "]"
+set: "{" expression ("," expression)* "}"
+tuple: "("args ")"
+dict_pair: expression ":" expression
 
 ?value_raw: SIGNED_FLOAT
       | SIGNED_INT
@@ -73,59 +93,40 @@ FALSE: "false"
 value_cast: value_raw "::" datatype
 
 ?value: value_raw
-      | CNAME
-      | value_cast
+    | value_cast
 
-?return: value_raw
-       | value_cast
+?return: value
 
-assign: datatype? CNAME "=" value
-      | assign_datatype CNAME "=" expr
-      | CNAME "=" constructor
+_property: "." CNAME
 
+property: "(" constructor ")" _property
+    | "(" expression ")" _property
+    | function _property
+    | property _property
+    | value _property
+    | variable _property
+    | global_variable _property
+
+
+args: [expression ("," expression)*]
+?arguments: "(" args ")"
+global_variable: "<" CNAME ">"
+?variable: CNAME
 ?name: CNAME
-    | expr "." CNAME
+    | property
 
-LCROOK: "<"
-RCROOK: ">"
+function: name arguments
+constructor: "new" function
 
-global_variable: LCROOK CNAME RCROOK
+?expression: "(" expression ")"
+    | global_variable
+    | variable
+    | value
+    | property
+    | function
+    | constructor
 
-property: expr "." CNAME
+assignment: assign_datatype? CNAME "=" expression
 
-constructor: "new" name "(" args ")"
-
-?expr: value
-     | fun
-     | constructor
-     | property
-     | global_variable
-
-fun: name "(" args ")"
-
-?stmt: assign
-     | expr
-
-args: [expr ("," expr)*]
-
-dict: "{" [dict_pair ("," dict_pair)*] "}"
-list: "[" [expr ("," expr)*] "]"
-set: "{" expr ("," expr)* "}"
-tuple: "(" [expr ("," expr)*] ")"
-dict_pair: expr ":" expr
-
-NULL: "null"
-UNDEFINED: "undefined"
-
-null: NULL
-    | UNDEFINED
-
-
-?string: ESCAPED_STRING
-
-%import common.CNAME
-%import common.ESCAPED_STRING
-%import common.SIGNED_INT
-%import common.SIGNED_FLOAT
-%import common.WS
-%ignore WS
+?statements: expression
+    | assignment

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -408,3 +408,10 @@ def test_parse_chained_property():
     assert namespace.namespace is None
     assert namespace.type == FunctionType.FUNCTION
     assert namespace.name == "get_container"
+
+
+def test_parse_global_variable():
+    parsed = parser.parse_statement('<data>')
+    assert parsed.type == FunctionType.PROPERTY
+    assert parsed.name == "data"
+    assert parsed.namespace is None

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -242,6 +242,11 @@ def test_parse_error_constructor_in_return_value2():
         parser.parse_value('{new data.Object(): "data"}')
 
 
+def test_parse_error_fun_assign():
+    with pytest.raises(ParseError):
+        parser.parse_statement('data = first([object.gen_int()])')
+
+
 def test_parse_fun_assign():
     assign = parser.parse_statement('integer data = first([object.gen_int()])')
     assert isinstance(assign, Assignment)
@@ -359,7 +364,7 @@ def test_parse_property():
 
 
 def test_parse_chained_constructor():
-    parsed = parser.parse_statement('new Container(5).get()')
+    parsed = parser.parse_statement('(new Container(5)).get()')
     assert parsed.type == FunctionType.FUNCTION
     assert parsed.name == "get"
     namespace = parsed.namespace

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -292,6 +292,29 @@ def test_parse_constructor_assign():
     assert len(data.arguments) == 0
 
 
+def test_parse_constructor_assign2():
+    assign = parser.parse_statement("cont = new Container({object.version})")
+    assert isinstance(assign, Assignment)
+    assert isinstance(assign.type, VariableType)
+    assert assign.type.data == "Container"
+    assert assign.variable == "cont"
+    expr = assign.expression
+    assert isinstance(expr, FunctionCall)
+    assert expr.namespace is None
+    assert expr.name == 'Container'
+    assert expr.type == FunctionType.CONSTRUCTOR
+    assert len(expr.arguments) == 1
+    arg = expr.arguments[0]
+    assert arg.type == BasicSequenceTypes.SET
+    assert len(arg.data) == 1
+    data = arg.data[0]
+    assert isinstance(data, FunctionCall)
+    assert data.type == FunctionType.PROPERTY
+    assert data.namespace == "object"
+    assert data.name == "version"
+    assert len(data.arguments) == 0
+
+
 def test_parse_value_assign():
     assign = parser.parse_statement("list lijst = [new Container(5, True)] :: list")
     assert isinstance(assign, Assignment)


### PR DESCRIPTION
Update the parser for the micro-programminglanguage from **early** to **lalr(1)**.
Therefor the grammar rules are also updated to be non-ambigue.

This has a speedup from  _6.796 s_ to _0.390 s_ for parsing the statements and expressions of the [Star Battle](https://dodona.ugent.be/nl/courses/453/series/4862/activities/39590992/submissions/) exercise, which is approximated 17 times faster.