### PR TITLE
Fix java default decimal value to double instead of float

### DIFF
--- a/tested/languages/java/templates/value_basic.mako
+++ b/tested/languages/java/templates/value_basic.mako
@@ -7,7 +7,7 @@
     ${value.data}\
 % elif value.type == BasicNumericTypes.RATIONAL:
     % if not isinstance(value.data, SpecialNumbers):
-        ${value.data}f\
+        ${value.data}\
     % elif value.data == SpecialNumbers.NOT_A_NUMBER:
         Double.NaN\
     % elif value.data == SpecialNumbers.POS_INFINITY:


### PR DESCRIPTION
Change the default decimal value notation in Java from `float` to `double`.