### PR TITLE
Hotfix: text evaluator:  fix actual values that are modified by the comparision options

### DIFF
--- a/tested/evaluators/text.py
+++ b/tested/evaluators/text.py
@@ -47,17 +47,20 @@ def compare_text(
         options: Dict[str, Any],
         expected: str,
         actual: str) -> EvaluationResult:
+    # Temporary variables that may modified by the evaluation options,
+    # Don't modify the actual values, otherwise there maybe confusion with the
+    # solution submitted by the student
+    expected_eval, actual_eval = str(expected), str(actual)
+
     if options['ignoreWhitespace']:
-        expected = expected.strip()
-        actual = actual.strip()
+        expected_eval, actual_eval = expected_eval.strip(), actual_eval.strip()
 
     if options['caseInsensitive']:
-        expected = expected.lower()
-        actual = actual.lower()
+        expected_eval, actual_eval = expected_eval.lower(), actual_eval.lower()
 
     if options['tryFloatingPoint'] and (
-            actual_float := _is_number(actual)) is not None:
-        expected_float = float(expected)
+            actual_float := _is_number(actual_eval)) is not None:
+        expected_float = float(expected_eval)
         if options['applyRounding']:
             numbers = int(options['roundTo'])
             # noinspection PyUnboundLocalVariable
@@ -66,9 +69,8 @@ def compare_text(
         # noinspection PyUnboundLocalVariable
         result = math.isclose(actual_float, expected_float)
         expected = str(expected_float)
-        actual = str(actual_float)
     else:
-        result = actual == expected
+        result = actual_eval == expected_eval
 
     return EvaluationResult(
         result=StatusMessage(enum=Status.CORRECT if result else Status.WRONG),

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -53,7 +53,7 @@ def test_text_evaluator_whitespace(tmp_path: Path, pytestconfig):
     result = evaluate_text(config, channel, "expected      ")
     assert result.result.enum == Status.CORRECT
     assert result.readable_expected == "expected"
-    assert result.readable_actual == "expected"
+    assert result.readable_actual == "expected      "
 
     result = evaluate_text(config, channel, "nothing")
     assert result.result.enum == Status.WRONG
@@ -71,7 +71,7 @@ def test_text_evaluator_case_sensitive(tmp_path: Path, pytestconfig):
     result = evaluate_text(config, channel, "Expected")
     assert result.result.enum == Status.CORRECT
     assert result.readable_expected == "expected"
-    assert result.readable_actual == "expected"
+    assert result.readable_actual == "Expected"
 
     result = evaluate_text(config, channel, "nothing")
     assert result.result.enum == Status.WRONG
@@ -90,7 +90,7 @@ def test_text_evaluator_combination(tmp_path: Path, pytestconfig):
     result = evaluate_text(config, channel, "Expected     ")
     assert result.result.enum == Status.CORRECT
     assert result.readable_expected == "expected"
-    assert result.readable_actual == "expected"
+    assert result.readable_actual == "Expected     "
 
     result = evaluate_text(config, channel, "nothing")
     assert result.result.enum == Status.WRONG
@@ -109,7 +109,7 @@ def test_text_evaluator_rounding(tmp_path: Path, pytestconfig):
     result = evaluate_text(config, channel, "1.3333333")
     assert result.result.enum == Status.CORRECT
     assert result.readable_expected == "1.333"
-    assert result.readable_actual == "1.333"
+    assert result.readable_actual == "1.3333333"
 
     result = evaluate_text(config, channel, "1.5")
     assert result.result.enum == Status.WRONG
@@ -129,7 +129,7 @@ def test_text_evaluator_round_to(tmp_path: Path, pytestconfig):
     result = evaluate_text(config, channel, "1.3333333")
     assert result.result.enum == Status.CORRECT
     assert result.readable_expected == "1.3"
-    assert result.readable_actual == "1.3"
+    assert result.readable_actual == "1.3333333"
 
     result = evaluate_text(config, channel, "1.5")
     assert result.result.enum == Status.WRONG


### PR DESCRIPTION
Avoid confusion (from the actual values) when comparing the values **caseInsensitive** and **ignoreWhitespace** when showing the results.