### PR TITLE
Add support for externalUrl in linter messages

### DIFF
--- a/exercise/echo/solution/correct.py
+++ b/exercise/echo/solution/correct.py
@@ -1,2 +1,4 @@
+string = "\z"
+
 i = input()
 print(i)

--- a/exercise/echo/solution/warning.sh
+++ b/exercise/echo/solution/warning.sh
@@ -1,0 +1,8 @@
+while getopts "vrn" n
+do
+  case "$n" in
+    v) echo "Verbose" ;;
+    r) echo "Recursive" ;;
+    \?) usage;;
+  esac
+done

--- a/tested/dodona.py
+++ b/tested/dodona.py
@@ -136,6 +136,7 @@ class AnnotateCode:
 
     row: Index
     text: str
+    externalUrl: str = None
     column: Optional[Index] = None
     type: Optional[Severity] = None
     rows: Optional[Index] = None

--- a/tested/languages/bash/linter.py
+++ b/tested/languages/bash/linter.py
@@ -63,24 +63,18 @@ def run_shellcheck(
     for shellcheck_object in shellcheck_objects:
         if Path(shellcheck_object.get("file", submission)).name != submission.name:
             continue
-        text = shellcheck_object.get("message", None)
+        text = shellcheck_object.get("message", "")
         code = shellcheck_object.get("code", None)
-        if not text and code is None:
+        if not text and not code:
             continue
-        elif not text:
-            text = (
-                f'(code <a href="https://github.com/koalaman/shellcheck/wiki/'
-                f'SC{code}" target="_blank">{code}</a>)'
-            )
-        elif code is not None:
-            text = (
-                f'{text} (code <a href="https://github.com/koalaman/'
-                f'shellcheck/wiki/SC{code}" target="_blank">{code}</a>)'
-            )
+        external = None
+        if code:
+            external = f"https://github.com/koalaman/shellcheck/wiki/SC{code}"
         annotations.append(
             AnnotateCode(
                 row=max(int(shellcheck_object.get("line", "-1")) - 1, 0),
                 text=text,
+                externalUrl=external,
                 column=max(int(shellcheck_object.get("column", "-1")) - 1, 0),
                 type=message_categories.get(
                     shellcheck_object.get("level", "warning"), Severity.WARNING

--- a/tested/languages/haskell/linter.py
+++ b/tested/languages/haskell/linter.py
@@ -69,12 +69,6 @@ def run_hlint(
         if not hint:
             continue
 
-        more_info = get_i18n_string("languages.linter.more-info")
-        hint = (
-            f'{hint} <a href="https://github.com/ndmitchell/hlint/blob/master/'
-            f'hints.md" target="_blank">({more_info})</a>'
-        )
-
         hint_from = hlint_message.get("from", None)
         hint_to = hlint_message.get("to", None)
         if hint_from and hint_to:
@@ -86,6 +80,7 @@ def run_hlint(
             AnnotateCode(
                 row=max(int(hlint_message.get("startLine", "-1")) - 1, 0),
                 text=hint,
+                externalUrl="https://github.com/ndmitchell/hlint/blob/master/hints.md",
                 column=max(int(hlint_message.get("startColumn", "-1")) - 1, 0),
                 type=message_categories.get(
                     hlint_message.get("severity", "warning"), Severity.WARNING

--- a/tested/languages/java/linter.py
+++ b/tested/languages/java/linter.py
@@ -71,17 +71,14 @@ def run_checkstyle(
             if not message:
                 continue
             source = error_element.attrib.get("source", None)
+            external = None
             if source:
-                more_info = get_i18n_string("languages.linter.more-info")
-                message += (
-                    f" (https://checkstyle.sourceforge.io/apidocs/"
-                    f'index.html?{source.replace(".", "/")}.html" '
-                    f'target="_blank">{more_info}</a>)'
-                )
+                external = f'https://checkstyle.sourceforge.io/apidocs/index.html?{source.replace(".", "/")}.html'
             annotations.append(
                 AnnotateCode(
                     row=max(int(error_element.attrib.get("line", "-1")) - 1, 0),
                     text=message,
+                    externalUrl=external,
                     column=max(int(error_element.attrib.get("column", "-1")) - 1, 0),
                     type=message_categories.get(
                         error_element.attrib.get("severity", "warning"),

--- a/tested/languages/javascript/linter.py
+++ b/tested/languages/javascript/linter.py
@@ -72,15 +72,14 @@ def run_eslint(
             if not text:
                 continue
             rule_id = message.get("ruleId")
+            external = None
             if rule_id:
-                text += (
-                    f' (<a href="https://eslint.org/docs/rules/{rule_id}" '
-                    f'target="_blank">{rule_id}</a>)'
-                )
+                external = f"https://eslint.org/docs/rules/{rule_id}"
             annotations.append(
                 AnnotateCode(
                     row=max(int(message.get("line", "-1")) - 1, 0),
                     text=text,
+                    externalUrl=external,
                     column=max(int(message.get("column", "-1")) - 1, 0),
                     type=severity[int(message.get("severity", 1))],
                 )

--- a/tested/languages/kotlin/linter.py
+++ b/tested/languages/kotlin/linter.py
@@ -86,16 +86,13 @@ def run_ktlint(
                 continue
             rule = error.get("rule", None)
             if rule:
-                more_info = get_i18n_string("languages.linter.more-info")
-                message += (
-                    f'({rule}, <a href="https://ktlint.github.io/#rules" '
-                    f'target="_blank">{more_info}</a>)'
-                )
+                message += f"({rule})"
 
             annotations.append(
                 AnnotateCode(
                     row=max(int(error.get("line", "-1")) - 1, 0),
                     text=message,
+                    externalUrl="https://ktlint.github.io/#rules",
                     column=max(int(error.get("column", "-1")) - 1, 0),
                     type=Severity.INFO,
                 )

--- a/tested/languages/python/linter.py
+++ b/tested/languages/python/linter.py
@@ -3,9 +3,7 @@ Support linting Python code.
 Most of this code is taken from the code from Pythia.
 """
 import logging
-import shutil
 from io import StringIO
-from os import PathLike
 from pathlib import Path
 from typing import List, Tuple
 
@@ -74,31 +72,23 @@ def run_pylint(
             message.get("type", "warning"), Severity.WARNING
         )
         logger.debug("Handling message %s", str(message))
-        message_id = message.get("message-id", None)
-        message_text = message.get("message", None)
-        more_info = get_i18n_string("languages.linter.more-info")
-        if not message_id and not message_text:
+        text = message.get("message", None)
+        symbol = message.get("symbol", None)
+        raw_type = message.get("type", None)
+
+        external = None
+        if not symbol and not text:
             continue
-        elif not message_id:
-            text = message_text
-        elif not message_text:
-            text = (
-                f'({message_id}, <a href="https://pylint.pycqa.org/en/latest/'
-                f'technical_reference/features.html#basic-checker-messages" '
-                f'target="_blank">{more_info}</a>)'
-            )
-        else:
-            text = (
-                f"{message_text} ({message_id},"
-                f'<a href="https://pylint.pycqa.org/en/latest/'
-                f'technical_reference/features.html#basic-checker-messages" '
-                f'target="_blank">{more_info}</a>)'
+        if symbol and raw_type:
+            external = (
+                f"https://pylint.pycqa.org/en/latest/messages/{raw_type}/{symbol}.html"
             )
         annotations.append(
             AnnotateCode(
                 row=max(int(message.get("line", "-1")) - 1, 0),
                 column=max(int(message.get("column", "-1")) - 1, 0),
                 text=text,
+                externalUrl=external,
                 type=category,
             )
         )

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -132,3 +132,14 @@ def test_shellcheck(tmp_path: Path, config, pytestconfig):
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
     assert len(updates.find_all("annotate-code")) > 0
+
+
+@pytest.mark.linter
+@pytest.mark.parametrize("config", _get_config_options("bash"))
+def test_shellcheck(tmp_path: Path, config, pytestconfig):
+    conf = configuration(
+        pytestconfig, "echo", "bash", tmp_path, "one.tson", "warning", config
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("annotate-code")) > 0

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -142,4 +142,6 @@ def test_shellcheck(tmp_path: Path, config, pytestconfig):
     )
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
-    assert len(updates.find_all("annotate-code")) > 0
+    assert len(updates.find_all("annotate-code")) == 1
+    [annotation] = updates.find_all("annotate-code")
+    assert annotation["externalUrl"]


### PR DESCRIPTION
Adds support for `externalUrl` in the linter messages where possible.

Fixes #286, as linter messages no longer contain HTML.
Superseeds #294, as this re-implements it on top of the black formatting changes.