### PR TITLE
Properly handle invalid utf8 in output streams

### DIFF
--- a/exercise/sum/solution/non-utf8-output.sh
+++ b/exercise/sum/solution/non-utf8-output.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+printf "This is invalid utf8: \xc3\x28"

--- a/tested/judge/utils.py
+++ b/tested/judge/utils.py
@@ -51,6 +51,7 @@ def run_command(
             command,
             cwd=directory,
             text=True,
+            errors="backslashreplace",
             capture_output=True,
             input=stdin,
             timeout=timeout,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,11 @@ import yaml
 from tested.description_instance import create_description_instance
 from tested.languages.config import limit_output
 from tested.utils import sorted_no_duplicates
+from tests.manual_utils import (
+    assert_valid_output,
+    configuration,
+    execute_config,
+)
 
 
 def test_javascript_ast_parse():
@@ -619,3 +624,12 @@ def test_valid_yaml_and_json():
                 yaml.safe_load(fd)
     # Test will always succeed if no exception is thrown
     assert True
+
+
+def test_invalid_utf8_output_is_caught(tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig, "sum", "bash", tmp_path, "short.tson", "non-utf8-output"
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["wrong"] * 5


### PR DESCRIPTION
The processes that run the generated executable are executed using `subprocess.run()`. By default, the output streams (e.g. stdout, stderr) are assumed to be in utf-8, using the "strict" mode. This means invalid utf8 in the output streams causes the judge to crash.

The fix is to enable the "backslashreplace" mode, which replaces invalid sequences by a backslash-escaped version.

See https://docs.python.org/3/library/io.html#io.TextIOWrapper.

Also adds a test for this issue.