### PR TITLE
Properly apply console syntax highlighting

### DIFF
--- a/tested/languages/description_generator.py
+++ b/tested/languages/description_generator.py
@@ -198,7 +198,7 @@ class DescriptionGenerator:
         stmt = self.language.cleanup_description(bundle.plan.namespace, stmt)
         if is_html:
             prompt = html.escape(self.types["console"]["prompt"]).strip()
-            stmt = self.generate_html_code(stmt)[41:-13].strip()
+            stmt = self.generate_html_code(stmt).strip()
             return (prompt + " " if statement else "") + stmt
         else:
             return (

--- a/tested/languages/description_generator.py
+++ b/tested/languages/description_generator.py
@@ -25,7 +25,16 @@ TYPE_CONFIG_NAME = Optional[Dict[str, Dict[str, Union[str, Dict[str, str]]]]]
 
 logger = logging.getLogger(__name__)
 
-_html_formatter = HtmlFormatter()
+_html_formatter = HtmlFormatter(nowrap=True)
+
+_console_lexer = get_lexer_by_name("console")
+
+
+def highlight_console(stmt):
+    """
+    Highlight a console statement.
+    """
+    return highlight(stmt, _console_lexer, _html_formatter)
 
 
 class DescriptionGenerator:

--- a/tested/languages/generator.py
+++ b/tested/languages/generator.py
@@ -16,6 +16,7 @@ from pygments.formatters.html import HtmlFormatter
 
 from .config import TemplateType
 from .templates import find_and_write_template, find_template
+from .description_generator import highlight_console
 from ..configs import Bundle
 from ..datatypes import BasicSequenceTypes
 from ..dodona import ExtendedMessage
@@ -540,10 +541,11 @@ def get_readable_input(
 
     if format_ == "text":
         generated_html = html.escape(text)
+    elif format_ == "console":
+        generated_html = highlight_console(text)
     else:
         generator = bundle.lang_config.get_description_generator()
-        # Slice to unwrapped generated div and pre tags
-        generated_html = generator.generate_html_code(text)[28:-14]
+        generated_html = generator.generate_html_code(text)
 
     if isinstance(case, RunTestcase):
         regex = re.compile(


### PR DESCRIPTION
Since we do syntax highlighting ourselves when there are files, we need to actually use the console highlighter. Additionally, disable wrapping of the output, so we don't need to slice the resulting HTML.