### PR TITLE
Don't use brackets for simple values in Haskell

### DIFF
--- a/tested/languages/haskell/templates/function.mako
+++ b/tested/languages/haskell/templates/function.mako
@@ -1,12 +1,17 @@
 ## This generates a function expression in Haskell.
-<%! from tested.serialisation import FunctionType %>\
+<%! from tested.serialisation import FunctionType, Value %>\
+<%! from tested.utils import get_args %>\
 <%page args="function" />\
 % if function.namespace:
     <%include file="statement.mako" args="statement=function.namespace"/>.\
 % endif
 ${function.name} \
 % for argument in function.arguments:
-    (<%include file="statement.mako" args="statement=argument"/>)\
+    % if isinstance(argument, get_args(Value)):
+        <%include file="statement.mako" args="statement=argument"/>\
+    % else:
+        (<%include file="statement.mako" args="statement=argument"/>)\
+    % endif
     % if not loop.last:
          \
     % endif

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,39 @@
+# Tests for language-specific stuff, often in response to issues.
+import sys
+from pathlib import Path
+
+from tested.configs import create_bundle
+from tested.datatypes import BasicBooleanTypes, BasicNumericTypes, BasicStringTypes
+from tested.languages.generator import convert_statement
+from tested.serialisation import (
+    BooleanType,
+    FunctionCall,
+    FunctionType,
+    NumberType,
+    StringType,
+)
+from tested.testsuite import Suite
+from tests.manual_utils import configuration
+
+
+def test_function_arguments_without_brackets(tmp_path: Path, pytestconfig):
+    conf = configuration(pytestconfig, "", "haskell", tmp_path)
+    plan = Suite()
+    bundle = create_bundle(conf, sys.stdout, plan)
+
+    statement = FunctionCall(
+        type=FunctionType.FUNCTION,
+        name="test",
+        namespace=None,
+        arguments=[
+            NumberType(type=BasicNumericTypes.REAL, data=5.5),
+            StringType(type=BasicStringTypes.TEXT, data="hallo"),
+            BooleanType(type=BasicBooleanTypes.BOOLEAN, data=True),
+        ],
+    )
+
+    result = convert_statement(bundle, statement)
+    assert (
+        result
+        == f'{bundle.lang_config.submission_name(plan)}.test 5.5 :: Double "hallo" True'
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -355,7 +355,7 @@ ${expression('[10, 5, 2, 8, 7, 1, 3, 4, 9, 6]')}"""
         ("c", ">", 'long long x = data(1, 2, "alpha");'),
         ("kotlin", ">", 'var x = data(1, 2, "alpha")'),
         ("javascript", ">", 'let x = data(1, 2, "alpha")'),
-        ("haskell", ">", 'let x = data (1 :: Int) (2 :: Int) ("alpha")'),
+        ("haskell", ">", 'let x = data 1 :: Int 2 :: Int "alpha"'),
     ],
 )
 def test_template_multi_line_code_block_markdown(lang: str, prompt: str, expected: str):


### PR DESCRIPTION
Fixes #293.