### PR TITLE
Add an option to enable compiler optimisations

### DIFF
--- a/tested/configs.py
+++ b/tested/configs.py
@@ -58,6 +58,15 @@ class Options:
     """
     If the custom Python evaluator should be optimized or not.
     """
+    compiler_optimizations: bool = False
+    """
+    If compiler optimizations should be enabled for languages that support them,
+    for example, C or Haskell.
+    This is disabled by default, as the additional time required in the compilation
+    step is often much larger than the gains in execution time for short exercises.
+    Longer exercises, or exercises where the solution might depend on optimization
+    may need this option.
+    """
 
 
 class DodonaConfig(BaseModel):

--- a/tested/languages/c/config.py
+++ b/tested/languages/c/config.py
@@ -67,6 +67,7 @@ class C(Language):
                 "gcc",
                 "-std=c11",
                 "-Wall",
+                "-O3" if bundle.config.options.compiler_optimizations else "-O0",
                 "evaluation_result.c",
                 "values.c",
                 main_file,

--- a/tested/languages/haskell/config.py
+++ b/tested/languages/haskell/config.py
@@ -17,7 +17,6 @@ from tested.languages.utils import (
 )
 
 
-# TODO: advanced type don't work very good at the moment.
 class Haskell(Language):
     def compilation(self, bundle: Bundle, files: List[str]) -> CallbackResult:
         main_ = files[-1]
@@ -26,7 +25,7 @@ class Haskell(Language):
             "ghc",
             "-fno-cse",
             "-fno-full-laziness",
-            "-O0",
+            "-O3" if bundle.config.options.compiler_optimizations else "-O0",
             main_,
             "-main-is",
             exec_,

--- a/tested/languages/kotlin/config.py
+++ b/tested/languages/kotlin/config.py
@@ -34,6 +34,7 @@ class Kotlin(Language):
             get_executable("kotlinc"),
             f"-J-Xmx192M",
             "-nowarn",
+            "-opt" if bundle.config.options.compiler_optimizations else "",
             "-jvm-target",
             "11",
             "-cp",

--- a/tested/languages/kotlin/config.py
+++ b/tested/languages/kotlin/config.py
@@ -34,7 +34,6 @@ class Kotlin(Language):
             get_executable("kotlinc"),
             f"-J-Xmx192M",
             "-nowarn",
-            "-opt" if bundle.config.options.compiler_optimizations else "",
             "-jvm-target",
             "11",
             "-cp",


### PR DESCRIPTION
Add config option to enable compiler optimisations, currently available for C, Haskell and Kotlin.


Fixes #292.