### PR TITLE
Clean up pylint config

### DIFF
--- a/tested/languages/python/pylint_config.rc
+++ b/tested/languages/python/pylint_config.rc
@@ -1,47 +1,12 @@
-[BASIC]
-
-function-rgx=[_A-Za-z0-9]{1,30}$
-method-rgx=[_A-Za-z0-9]{1,30}$
-attr-rgx=[_A-Za-z0-9_]{1,30}$
-argument-rgx=[_A-Za-z0-9]{1,30}$
-variable-rgx=[_A-Za-z0-9]{1,30}$
-inlinevar-rgx=[_A-Za-z0-9]{1,30}$
-const-rgx=[_A-Za-z0-9]{1,30}$
-
 [MESSAGES CONTROL]
 
-#-W0123 Eval is evil.
-#-W0141 Used builtin function %r (input,zip,filter,...).
-# W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
-#-W0201 Attribute %r defined outside __init__
-#-W0212 Access to a protected member %s of a client class
-#-W0232 Class has no __init__ method; used when a class has no __init__ method, neither its parent classes.
-#-W0614 Unused import XYZ from wildcard import
 # W0621 Redefining name %r from outer scope
 # W0622 Redefining built-in %r
-#-W0631 Using possibly undefined loop variable
-#-W0702 No exception's type specified; used when an except clause doesn't specify exceptions type to catch.
-#-W0704 Except doesn't do anything; used when an except clause does nothing but "pass" and there is no "else" clause
-#-W1304 Unused format argument
-#-R0201 Used when there is no reference to the class, suggesting that the method could be used as a static function instead
-#-R0801 Similar lines in %s files
 # R0902 Too many instance attributes (maximal 7 allowed)
 # R0903 Too few public methods
-#-R0904 Too many public methods
-#-R0911 Too many return statements
-#-R0912 Too many branches
-#-R0913 Too many arguments
-#-R0914 Too many local variables
-#-R0915 Too many statements
+# R0904 Too many public methods
+# R0911 Too many return statements
 # C0111 Missing docstring
 # C0301 Line too long
-# C0303 Trailing whitespace
-# C0304 Final newline missing
-# C0330 Wrong continued indentation.
-# C0413 Import "{}" should be placed at the top of the module.
-#-C1001 Old-style class defined
 # I0011 Warning locally suppressed using disable-msg
-# I0012 Warning locally suppressed using disable-msg
-# old version: disable=I0011,I0012,W0704,W0142,W0212,W0232,W0702,R0201,W0614,R0914,R0912,R0915,R0913,R0904,R0801,C0303,C0111,C0304,R0903,W0141,W0621,C0301,W0631,R0911,C1001
-disable=W0142,W0621,W0622,R0902,R0903,C0111,C0301,C0303,C0304,C0330,C0413,I0011,I0012
-evaluation=max(10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10), 0)
+disable=W0621,W0622,R0902,R0903,R0904,R0911,C0111,C0301,I0011


### PR DESCRIPTION
Prevent warnings about non-existing suppression, and clean up the file in general.

Example of the warnings: https://dodona.ugent.be/nl/submissions/13785286/