### PR TITLE
Support multiline and multicolumn linters

### DIFF
--- a/tested/languages/bash/linter.py
+++ b/tested/languages/bash/linter.py
@@ -70,12 +70,20 @@ def run_shellcheck(
         external = None
         if code:
             external = f"https://github.com/koalaman/shellcheck/wiki/SC{code}"
+        start_row = shellcheck_object.get("line", 1)
+        end_row = shellcheck_object.get("endLine")
+        rows = end_row - start_row if end_row else None
+        start_col = shellcheck_object.get("column", 1)
+        end_col = shellcheck_object.get("endColumn")
+        cols = end_col - start_col if end_col else None
         annotations.append(
             AnnotateCode(
-                row=max(int(shellcheck_object.get("line", "-1")) - 1, 0),
+                row=start_row - 1 + bundle.config.source_offset,
+                rows=rows,
                 text=text,
                 externalUrl=external,
-                column=max(int(shellcheck_object.get("column", "-1")) - 1, 0),
+                column=start_col - 1,
+                columns=cols,
                 type=message_categories.get(
                     shellcheck_object.get("level", "warning"), Severity.WARNING
                 ),

--- a/tested/languages/c/linter.py
+++ b/tested/languages/c/linter.py
@@ -72,20 +72,19 @@ def run_cppcheck(
             if not message:
                 continue
             severity = error.attrib.get("severity", "warning")
-            position = None
+            row = None
+            col = None
             for el in error:
                 if el.tag != "location":
                     continue
-                position = (
-                    max(int(el.attrib.get("line", "-1")) - 1, 0),
-                    max(int(el.attrib.get("column", "-1")) - 1, 0),
-                )
+                row = int(el.attrib.get("line", "1")) - 1 + bundle.config.source_offset
+                col = int(el.attrib.get("column", "1")) - 1
                 break
             annotations.append(
                 AnnotateCode(
-                    row=position[0],
+                    row=row,
                     text=message,
-                    column=position[1],
+                    column=col,
                     type=message_categories.get(severity, Severity.WARNING),
                 )
             )

--- a/tested/languages/haskell/linter.py
+++ b/tested/languages/haskell/linter.py
@@ -76,12 +76,21 @@ def run_hlint(
         if notes:
             hint = f"{hint}\n{notes}"
 
+        start_row = hlint_message.get("startLine", 1)
+        end_row = hlint_message.get("endLine")
+        rows = end_row - start_row if end_row else None
+        start_col = hlint_message.get("startColumn", 1)
+        end_col = hlint_message.get("endColumn")
+        cols = end_col - start_col if end_col else None
+
         annotations.append(
             AnnotateCode(
-                row=max(int(hlint_message.get("startLine", "-1")) - 1, 0),
+                row=start_row - 1 + bundle.config.source_offset,
+                rows=rows,
                 text=hint,
                 externalUrl="https://github.com/ndmitchell/hlint/blob/master/hints.md",
-                column=max(int(hlint_message.get("startColumn", "-1")) - 1, 0),
+                column=start_col - 1,
+                columns=cols,
                 type=message_categories.get(
                     hlint_message.get("severity", "warning"), Severity.WARNING
                 ),

--- a/tested/languages/java/linter.py
+++ b/tested/languages/java/linter.py
@@ -76,10 +76,12 @@ def run_checkstyle(
                 external = f'https://checkstyle.sourceforge.io/apidocs/index.html?{source.replace(".", "/")}.html'
             annotations.append(
                 AnnotateCode(
-                    row=max(int(error_element.attrib.get("line", "-1")) - 1, 0),
+                    row=int(error_element.attrib.get("line", "1"))
+                    - 1
+                    + bundle.config.source_offset,
                     text=message,
                     externalUrl=external,
-                    column=max(int(error_element.attrib.get("column", "-1")) - 1, 0),
+                    column=int(error_element.attrib.get("column", "1")) - 1,
                     type=message_categories.get(
                         error_element.attrib.get("severity", "warning"),
                         Severity.WARNING,

--- a/tested/languages/javascript/linter.py
+++ b/tested/languages/javascript/linter.py
@@ -75,12 +75,21 @@ def run_eslint(
             external = None
             if rule_id:
                 external = f"https://eslint.org/docs/rules/{rule_id}"
+
+            start_row = message.get("line", 1)
+            end_row = message.get("endLine") + 1
+            rows = end_row - start_row if end_row else None
+            start_col = message.get("column", 1)
+            end_col = message.get("endColumn") + 1
+            cols = end_col - start_col if end_col else None
             annotations.append(
                 AnnotateCode(
-                    row=max(int(message.get("line", "-1")) - 1, 0),
+                    row=start_row - 1 + bundle.config.source_offset,
+                    rows=rows,
                     text=text,
                     externalUrl=external,
-                    column=max(int(message.get("column", "-1")) - 1, 0),
+                    column=start_col - 1,
+                    columns=cols,
                     type=severity[int(message.get("severity", 1))],
                 )
             )

--- a/tested/languages/javascript/linter.py
+++ b/tested/languages/javascript/linter.py
@@ -77,11 +77,11 @@ def run_eslint(
                 external = f"https://eslint.org/docs/rules/{rule_id}"
 
             start_row = message.get("line", 1)
-            end_row = message.get("endLine") + 1
-            rows = end_row - start_row if end_row else None
+            end_row = message.get("endLine")
+            rows = end_row + 1 - start_row if end_row else None
             start_col = message.get("column", 1)
-            end_col = message.get("endColumn") + 1
-            cols = end_col - start_col if end_col else None
+            end_col = message.get("endColumn")
+            cols = end_col + 1 - start_col if end_col else None
             annotations.append(
                 AnnotateCode(
                     row=start_row - 1 + bundle.config.source_offset,

--- a/tested/languages/kotlin/linter.py
+++ b/tested/languages/kotlin/linter.py
@@ -90,7 +90,7 @@ def run_ktlint(
 
             annotations.append(
                 AnnotateCode(
-                    row=error.get("line", 1) - 1,
+                    row=error.get("line", 1) - 1 + bundle.config.source_offset,
                     text=message,
                     externalUrl="https://ktlint.github.io/#rules",
                     column=error.get("column", 1) - 1,

--- a/tested/languages/kotlin/linter.py
+++ b/tested/languages/kotlin/linter.py
@@ -90,10 +90,10 @@ def run_ktlint(
 
             annotations.append(
                 AnnotateCode(
-                    row=max(int(error.get("line", "-1")) - 1, 0),
+                    row=error.get("line", 1) - 1,
                     text=message,
                     externalUrl="https://ktlint.github.io/#rules",
-                    column=max(int(error.get("column", "-1")) - 1, 0),
+                    column=error.get("column", 1) - 1,
                     type=Severity.INFO,
                 )
             )

--- a/tested/languages/python/linter.py
+++ b/tested/languages/python/linter.py
@@ -83,10 +83,20 @@ def run_pylint(
             external = (
                 f"https://pylint.pycqa.org/en/latest/messages/{raw_type}/{symbol}.html"
             )
+
+        start_row = message.get("line", 1)
+        end_row = message.get("endLine") + 1
+        rows = end_row - start_row if end_row else None
+        start_col = message.get("column", 1)
+        end_col = message.get("endColumn") + 1
+        cols = end_col - start_col if end_col else None
+
         annotations.append(
             AnnotateCode(
-                row=max(int(message.get("line", "-1")) - 1, 0),
-                column=max(int(message.get("column", "-1")) - 1, 0),
+                row=start_row - 1 + bundle.config.source_offset,
+                rows=rows,
+                column=start_col - 1,
+                columns=cols,
                 text=text,
                 externalUrl=external,
                 type=category,

--- a/tested/languages/python/linter.py
+++ b/tested/languages/python/linter.py
@@ -85,11 +85,11 @@ def run_pylint(
             )
 
         start_row = message.get("line", 1)
-        end_row = message.get("endLine") + 1
-        rows = end_row - start_row if end_row else None
+        end_row = message.get("endLine")
+        rows = end_row + 1 - start_row if end_row else None
         start_col = message.get("column", 1)
-        end_col = message.get("endColumn") + 1
-        cols = end_col - start_col if end_col else None
+        end_col = message.get("endColumn")
+        cols = end_col + 1 - start_col if end_col else None
 
         annotations.append(
             AnnotateCode(

--- a/tested/languages/python/linter.py
+++ b/tested/languages/python/linter.py
@@ -84,18 +84,18 @@ def run_pylint(
                 f"https://pylint.pycqa.org/en/latest/messages/{raw_type}/{symbol}.html"
             )
 
-        start_row = message.get("line", 1)
+        start_row = message.get("line", 0)
         end_row = message.get("endLine")
         rows = end_row + 1 - start_row if end_row else None
-        start_col = message.get("column", 1)
+        start_col = message.get("column", 0)
         end_col = message.get("endColumn")
-        cols = end_col + 1 - start_col if end_col else None
+        cols = end_col - start_col if end_col else None
 
         annotations.append(
             AnnotateCode(
                 row=start_row - 1 + bundle.config.source_offset,
                 rows=rows,
-                column=start_col - 1,
+                column=start_col,
                 columns=cols,
                 text=text,
                 externalUrl=external,


### PR DESCRIPTION
Support the `rows` and `columns` property in annotations for those linters that support it. We ignored these parameters, Dodona didn't do anything with them, but this will probably change in the future.

Also fix a line offset bug when using the shebang.

Related: https://github.com/dodona-edu/dodona/pull/4568