### PR TITLE
Sync Pylint with Python judge

### DIFF
--- a/tested/languages/python/pylint_config.rc
+++ b/tested/languages/python/pylint_config.rc
@@ -6,7 +6,8 @@
 # R0903 Too few public methods
 # R0904 Too many public methods
 # R0911 Too many return statements
+# C0103 Invalid name %r
 # C0111 Missing docstring
 # C0301 Line too long
 # I0011 Warning locally suppressed using disable-msg
-disable=W0621,W0622,R0902,R0903,R0904,R0911,C0111,C0301,I0011
+disable=W0621,W0622,R0902,R0903,R0904,R0911,C0103,C0111,C0301,I0011


### PR DESCRIPTION
This check results in many false positives, especially since a lot of problem statements give a one-letter name to variables. Additionally, some exercises use camel-case.

Fixes #351.