### PR TITLE
Re-allow plain JS objects as exceptions

### DIFF
--- a/tested/languages/javascript/templates/values.js
+++ b/tested/languages/javascript/templates/values.js
@@ -91,14 +91,24 @@ function sendException(stream, exception) {
             "type": exception.constructor.name
         }));
     } else {
-        additional_error =
-        // We have something else, so we cannot rely on stuff being present.
-        fs.writeSync(stream, JSON.stringify({
-            "message": JSON.stringify(exception),
-            "stacktrace": "",
-            "type": exception.constructor.name,
-            "additional_message_keys": ["languages.javascript.runtime.invalid.exception"]
-        }));
+        // Temporarily allow objects with "message" and "name".
+        // TODO: remove this once the semester is over
+        // noinspection PointlessBooleanExpressionJS
+        if (typeof exception === 'object') {
+            fs.writeSync(stream, JSON.stringify({
+                "message": exception.message ?? "",
+                "stacktrace": "",
+                "type": exception.name ?? ""
+            }));
+        } else {
+            // We have something else, so we cannot rely on stuff being present.
+            fs.writeSync(stream, JSON.stringify({
+                "message": JSON.stringify(exception),
+                "stacktrace": "",
+                "type": exception.constructor.name ?? (Object.prototype.toString.call(exception)),
+                "additional_message_keys": ["languages.javascript.runtime.invalid.exception"]
+            }));
+        }
     }
 }
 

--- a/tests/exercises/js-exceptions/solution/correct-temp.js
+++ b/tests/exercises/js-exceptions/solution/correct-temp.js
@@ -1,0 +1,4 @@
+throw {
+    name: "AssertionError",
+    message: "Valid exceptions"
+}

--- a/tests/exercises/js-exceptions/solution/wrong-null.js
+++ b/tests/exercises/js-exceptions/solution/wrong-null.js
@@ -1,0 +1,1 @@
+throw null;

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -802,6 +802,21 @@ def test_javascript_exception_correct(tmp_path: Path, pytestconfig):
     assert len(updates.find_all("append-message")) == 0
 
 
+def test_javascript_exception_correct_temp(tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "js-exceptions",
+        "javascript",
+        tmp_path,
+        "plan.yaml",
+        "correct-temp",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"]
+    assert len(updates.find_all("append-message")) == 0
+
+
 def test_javascript_exception_wrong(tmp_path: Path, pytestconfig):
     conf = configuration(
         pytestconfig,
@@ -815,6 +830,21 @@ def test_javascript_exception_wrong(tmp_path: Path, pytestconfig):
     updates = assert_valid_output(result, pytestconfig)
     assert updates.find_status_enum() == ["wrong"]
     assert len(updates.find_all("append-message")) == 1
+
+
+def test_javascript_exception_wrong_null(tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "js-exceptions",
+        "javascript",
+        tmp_path,
+        "plan.yaml",
+        "wrong-null",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["wrong"]
+    assert len(updates.find_all("append-message")) == 0
 
 
 def test_javascript_exception_missing_message(tmp_path: Path, pytestconfig):


### PR DESCRIPTION
We don't want to change this behaviour in the middle of the course, but after this semester, we will remove this special case.

For example: https://dodona.ugent.be/nl/submissions/14015216.