### PR TITLE
Pretty print multiline string if no actual value

### DIFF
--- a/tested/evaluators/value.py
+++ b/tested/evaluators/value.py
@@ -216,6 +216,15 @@ def evaluate(
     else:
         expected, readable_expected, actual, readable_actual = result
 
+    # Special pretty printing for multiline strings.
+    is_multiline_string = (
+        config.options.get("stringsAsText", True)
+        and expected.type == BasicStringTypes.TEXT
+        and "\n" in expected.data
+    )
+    if is_multiline_string:
+        readable_expected = get_as_string(expected, readable_expected)
+
     # If the channel value is not None, but actual is, error.
     if actual is None:
         return EvaluationResult(
@@ -248,22 +257,15 @@ def evaluate(
 
     correct = type_check and content_check
 
-    is_multiline_string = (
-        config.options.get("stringsAsText", True)
-        and expected.type == BasicStringTypes.TEXT
-        and "\n" in expected.data
-    )
+    if is_multiline_string:
+        readable_actual = get_as_string(actual, readable_actual)
 
     return EvaluationResult(
         result=StatusMessage(
             human=type_status, enum=Status.CORRECT if correct else Status.WRONG
         ),
-        readable_expected=get_as_string(expected, readable_expected)
-        if is_multiline_string
-        else readable_expected,
-        readable_actual=get_as_string(actual, readable_actual)
-        if is_multiline_string
-        else readable_actual,
+        readable_expected=readable_expected,
+        readable_actual=readable_actual,
         messages=messages,
         is_multiline_string=is_multiline_string,
     )

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -425,3 +425,18 @@ def test_value_string_as_text_is_not_detected_if_not_multiline(
     assert result.result.enum == Status.WRONG
     assert result.readable_expected == "'multi'"
     assert result.readable_actual == "'multi\\nline\\nstring'"
+
+
+def test_value_string_as_text_is_detected_when_no_actual(tmp_path: Path, pytestconfig):
+    channel = ValueOutputChannel(
+        value=StringType(type=BasicStringTypes.TEXT, data="multi\nline\nstring")
+    )
+    actual_value = json.dumps(
+        StringType(type=BasicStringTypes.TEXT, data="multi\nline\nstring"),
+        default=pydantic_encoder,
+    )
+    config = evaluator_config(tmp_path, pytestconfig, language="python")
+    result = evaluate_value(config, channel, "")
+    assert result.result.enum == Status.WRONG
+    assert result.readable_expected == "multi\nline\nstring"
+    assert result.readable_actual == ""


### PR DESCRIPTION
Our support for pretty printing multiline strings was too late in the process: if there was no actual value, we returned early, before the multiline pretty printing was applied.

By moving the multiline pretty printing support to the front, we should cover all cases.

Fixes #368.