### PR TITLE
Improve (JS) compiler output

### DIFF
--- a/tested/internationalization/en.yaml
+++ b/tested/internationalization/en.yaml
@@ -49,9 +49,6 @@ en:
         message: "Expected value of type %{expected}, but was type %{actual}."
   judge:
     compilation:
-      received:
-        stderr: "Received stderr from compiler:"
-        stdout: "Received stdout from compiler:"
       exitcode: "Exitcode %{exitcode}."
     core:
       unsupported:

--- a/tested/internationalization/nl.yaml
+++ b/tested/internationalization/nl.yaml
@@ -49,9 +49,6 @@ nl:
         message: "Verwachtte waarde van type %{expected}, maar was type %{actual}."
   judge:
     compilation:
-      received:
-        stderr: "De compiler produceerde volgende uitvoer op stderr:"
-        stdout: "De compiler produceerde volgende uitvoer op stdout:"
       exitcode: "Exitcode %{exitcode}."
     core:
       unsupported:

--- a/tested/judge/compilation.py
+++ b/tested/judge/compilation.py
@@ -87,7 +87,6 @@ def process_compile_results(
     # Report stderr.
     if stderr:
         # Append compiler messages to the output.
-        messages.append(get_i18n_string("judge.compilation.received.stderr"))
         messages.append(language_config.clean_stacktrace_to_message(stderr))
         _logger.debug("Received stderr from compiler: " + stderr)
         show_stdout = True
@@ -96,7 +95,6 @@ def process_compile_results(
     # Report stdout.
     if stdout and (show_stdout or results.exit != 0):
         # Append compiler messages to the output.
-        messages.append(get_i18n_string("judge.compilation.received.stdout"))
         messages.append(language_config.clean_stacktrace_to_message(stdout))
         _logger.debug("Received stdout from compiler: " + stdout)
         shown_messages = True

--- a/tested/languages/javascript/config.py
+++ b/tested/languages/javascript/config.py
@@ -151,7 +151,11 @@ class JavaScript(Language):
         # 1a. While inside the submission code, replace all references to the location with <code>
         # 1b. Remove any "submission.SOMETHING" -> "SOMETHING"
         # 2. Once we encounter a line with the execution location, skip all lines.
-        submission_location_regex = f"{self.config.dodona.workdir}/{EXECUTION_PREFIX}[_0-9]+/{submission_file(self)}"
+        execution_submission_location_regex = f"{self.config.dodona.workdir}/{EXECUTION_PREFIX}[_0-9]+/{submission_file(self)}"
+        submission_location = (
+            self.config.dodona.workdir / "common" / submission_file(self)
+        )
+        compilation_submission_location = str(submission_location.resolve())
         execution_location_regex = f"{self.config.dodona.workdir}/{EXECUTION_PREFIX}[_0-9]+/{EXECUTION_PREFIX}[_0-9]+.js"
         submission_namespace = f"{submission_name(self)}."
 
@@ -162,7 +166,8 @@ class JavaScript(Language):
                 break
 
             # Replace any reference to the submission.
-            line = re.sub(submission_location_regex, "<code>", line)
+            line = re.sub(execution_submission_location_regex, "<code>", line)
+            line = line.replace(compilation_submission_location, "<code>")
             # Remove any references of the form "submission.SOMETHING"
             line = line.replace(submission_namespace, "")
             resulting_lines += line

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -72,3 +72,34 @@ def test_javascript_empty():
     expected_cleaned = ""
     actual_cleaned = language_config.cleanup_stacktrace(original)
     assert actual_cleaned == expected_cleaned
+
+
+def test_javascript_compilation_error():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "javascript")
+    original = f"""
+    {workdir}/common/submission.js:4
+    const deepcopy = cellen => cellen.map(([x, y]) => [x, y]));
+                                                             ^
+    
+    SyntaxError: Unexpected token ')'
+        at internalCompileFunction (node:internal/vm:73:18)
+        at wrapSafe (node:internal/modules/cjs/loader:1176:20)
+        at checkSyntax (node:internal/main/check_syntax:67:3)
+    
+    Node.js v18.15.0
+    """
+    expected_cleaned = """
+    <code>:4
+    const deepcopy = cellen => cellen.map(([x, y]) => [x, y]));
+                                                             ^
+    
+    SyntaxError: Unexpected token ')'
+        at internalCompileFunction (node:internal/vm:73:18)
+        at wrapSafe (node:internal/modules/cjs/loader:1176:20)
+        at checkSyntax (node:internal/main/check_syntax:67:3)
+    
+    Node.js v18.15.0
+    """
+    actual_cleaned = language_config.cleanup_stacktrace(original)
+    assert actual_cleaned == expected_cleaned


### PR DESCRIPTION
- The message indicating where the error was produced has been removed (for all languages).
- The JavaScript stacktrace cleaning has been improved to add `<code>` links in compiler stacktraces.

Fixes #366