### PR TITLE
Improve handling of unknown return types

### DIFF
--- a/tested/datatypes/basic.py
+++ b/tested/datatypes/basic.py
@@ -15,6 +15,7 @@ class BasicNumericTypes(StrEnum):
 class BasicStringTypes(StrEnum):
     TEXT = auto()
     ANY = auto()  # Cannot be used in a test suite.
+    UNKNOWN = auto()  # Cannot be used in a test suite.
 
 
 @unique

--- a/tested/evaluators/exception.py
+++ b/tested/evaluators/exception.py
@@ -12,7 +12,6 @@ from tested.internationalization import get_i18n_string
 from tested.languages.utils import convert_stacktrace_to_clickable_feedback
 from tested.serialisation import ExceptionValue
 from tested.testsuite import ExceptionOutputChannel
-from tested.utils import Either
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +20,10 @@ class _ExceptionValue(BaseModel):
     __root__: ExceptionValue
 
 
-def try_as_exception(config: EvaluatorConfig, value: str) -> Either[ExceptionValue]:
-    try:
-        actual = _ExceptionValue.parse_raw(value).__root__
-        actual.stacktrace = config.bundle.lang_config.cleanup_stacktrace(
-            actual.stacktrace
-        )
-        return Either(actual)
-    except (TypeError, ValueError) as e:
-        return Either(e)
+def try_as_exception(config: EvaluatorConfig, value: str) -> ExceptionValue:
+    actual = _ExceptionValue.parse_raw(value).__root__
+    actual.stacktrace = config.bundle.lang_config.cleanup_stacktrace(actual.stacktrace)
+    return actual
 
 
 def try_as_readable_exception(
@@ -78,7 +72,7 @@ def evaluate(
         )
 
     try:
-        actual = try_as_exception(config, actual).get()
+        actual = try_as_exception(config, actual)
     except (TypeError, ValueError) as e:
         staff_message = ExtendedMessage(
             description=get_i18n_string(

--- a/tested/evaluators/programmed.py
+++ b/tested/evaluators/programmed.py
@@ -3,7 +3,7 @@ Programmed evaluator.
 """
 import logging
 import traceback
-from typing import Optional, Tuple
+from typing import Optional
 
 from tested.datatypes import StringTypes
 from tested.dodona import ExtendedMessage, Permission, Status, StatusMessage
@@ -12,20 +12,13 @@ from tested.evaluators.common import (
     EvaluatorConfig,
     cleanup_specific_programmed,
 )
-from tested.evaluators.value import get_values, try_as_value
+from tested.evaluators.value import get_values
 from tested.internationalization import get_i18n_string
 from tested.judge.programmed import evaluate_programmed
 from tested.judge.utils import BaseExecutionResult
 from tested.serialisation import EvalResult, StringType, Value
-from tested.testsuite import (
-    ExceptionOutputChannel,
-    FileOutputChannel,
-    NormalOutputChannel,
-    ProgrammedEvaluator,
-    TextOutputChannel,
-    ValueOutputChannel,
-)
-from tested.utils import Either, get_args
+from tested.testsuite import NormalOutputChannel, ProgrammedEvaluator
+from tested.utils import get_args
 
 _logger = logging.getLogger(__name__)
 
@@ -41,34 +34,6 @@ def _maybe_string(value_: str) -> Optional[Value]:
 
 def _try_specific(value_: str) -> EvalResult:
     return EvalResult.parse_raw(value_)
-
-
-def expected_as_value(
-    config: EvaluatorConfig, channel: NormalOutputChannel, actual: str
-) -> Tuple[Optional[Value], Either[Value]]:
-    if isinstance(channel, TextOutputChannel):
-        expected = channel.get_data_as_string(config.bundle.config.resources)
-        expected_value = _maybe_string(expected)
-        actual_value = StringType(StringTypes.TEXT, expected)
-        return expected_value, Either(actual_value)
-
-    if isinstance(channel, FileOutputChannel):
-        expected = _maybe_string(channel.expected_path)
-        actual = StringType(type=StringTypes.TEXT, data=channel.actual_path)
-        return expected, Either(actual)
-
-    if isinstance(channel, ValueOutputChannel):
-        expected = channel.value
-        try:
-            actual = try_as_value(actual).get()
-        except (ValueError, TypeError) as e:
-            return expected, Either(e)
-        return expected, Either(actual)
-
-    if isinstance(channel, ExceptionOutputChannel):
-        raise AssertionError("Programmed evaluation is not support for exceptions.")
-
-    raise AssertionError(f"Unknown channel type for {channel}.")
 
 
 def evaluate(

--- a/tested/languages/csharp/templates/Values.cs
+++ b/tested/languages/csharp/templates/Values.cs
@@ -23,6 +23,7 @@ namespace Tested
         private static Dictionary<string, object?> internalEncode(Object? value) {
             string type;
             object? data = value;
+            string? diagnostic = null;
 
             if (value == null) {
                 type = "nothing";
@@ -96,10 +97,13 @@ namespace Tested
                 data = entries;
             } else {
                 type = "unknown";
+                diagnostic = data.GetType().ToString();
+                data = JsonSerializer.Serialize(data);
             }
             var result = new Dictionary<string, object?>();
             result.Add("type", type);
             result.Add("data", data);
+            result.Add("diagnostic", diagnostic);
             return result;
         }
 

--- a/tested/languages/java/templates/Values.java
+++ b/tested/languages/java/templates/Values.java
@@ -45,6 +45,7 @@ public class Values {
     private static List<String> internalEncode(Object value) {
         String type;
         String data;
+        String diagnostic = null;
 
         if (value == null) {
             type = "nothing";
@@ -120,13 +121,16 @@ public class Values {
         } else {
             type = "unknown";
             data = "\"" + escape(value.toString()) + "\"";
+            diagnostic = "\"" + escape(((Object) value).getClass().getName()) + "\"";
         }
-        return List.of(type, data);
+        return Arrays.asList(type, data, diagnostic);
     }
 
     private static String encode(Object value) {
         var typeAndData = internalEncode(value);
-        return "{ \"data\": " + typeAndData.get(1) + ", \"type\": \"" + typeAndData.get(0) + "\"}";
+        return "{ \"data\": " + typeAndData.get(1) + "," +
+                " \"type\": \"" + typeAndData.get(0) + "\", " +
+                " \"diagnostic\": " + typeAndData.get(2) + "}";
     }
 
     public static void send(PrintWriter writer, Object value) {

--- a/tested/languages/javascript/templates/values.js
+++ b/tested/languages/javascript/templates/values.js
@@ -4,9 +4,11 @@ const fs = require("fs");
 function encode(value) {
 
     let type;
+    let diagnostic = null;
 
     if (typeof value === "undefined") {
         type = "undefined";
+        data = null;
     } else if (typeof value === "boolean") {
         type = "boolean";
     } else if (typeof value === "number") {
@@ -52,7 +54,8 @@ function encode(value) {
                                 };
                             }
                     );
-        } else {
+        } else if (value?.constructor === Object) {
+            // Plain objects
             type = "map";
             // Process the elements of the object.
             value = Object.entries(value).map(([key, value]) => {
@@ -61,14 +64,21 @@ function encode(value) {
                     value: encode(value)
                 };
             });
+        } else {
+            type = "unknown";
+            diagnostic = value?.constructor?.name;
+            value = JSON.stringify(value);
         }
     } else {
         type = "unknown";
+        diagnostic = value?.constructor?.name;
+        value = Object.prototype.toString.call(value);
     }
 
     return {
         type: type,
-        data: value
+        data: value,
+        diagnostic: diagnostic
     };
 
 }

--- a/tested/languages/kotlin/templates/Values.kt
+++ b/tested/languages/kotlin/templates/Values.kt
@@ -37,13 +37,17 @@ private fun encodeSequence(objects: Iterable<Any?>): String {
 
 private fun encode(value: Any?): String {
     val typeAndData = internalEncode(value)
-    return String.format("{ \"data\": %s, \"type\": \"%s\"}",
-            typeAndData[1], typeAndData[0])
+    if (typeAndData[2] != null) {
+        return String.format("{ \"data\": %s, \"type\": \"%s\", \"diagnostic\": \"%s\"}", typeAndData[1], typeAndData[0], typeAndData[2])
+    } else {
+        return String.format("{ \"data\": %s, \"type\": \"%s\"}", typeAndData[1], typeAndData[0])
+    }
 }
 
-private fun internalEncode(value: Any?): Array<String> {
+private fun internalEncode(value: Any?): Array<String?> {
     val type: String
     val data: String
+    var diagnostic: String? = null
 
     if (value == null) {
         type = "nothing"
@@ -127,11 +131,12 @@ private fun internalEncode(value: Any?): Array<String> {
                 }
                 .joinToString(separator = ", ", prefix = "[", postfix = "]")
     } else {
-        type = value::class.simpleName.toString()
-        data = String.format("\"%s\"", escape(value.toString()));
+        type = "unknown"
+        data = String.format("\"%s\"", escape(value.toString()))
+        diagnostic = value::class.simpleName
     }
 
-    return arrayOf(type, data)
+    return arrayOf(type, data, diagnostic)
 }
 
 fun evaluated(writer: PrintWriter, result: Boolean, expected: String?,

--- a/tested/languages/python/templates/values.py
+++ b/tested/languages/python/templates/values.py
@@ -8,6 +8,7 @@ import traceback
 
 
 def encode(value):
+    diagnostic = None
     if value is None:
         type_ = "nothing"
         data_ = value
@@ -55,8 +56,9 @@ def encode(value):
     else:
         type_ = "unknown"
         data_ = str(value)
+        diagnostic = str(type(value))
 
-    return {"data": data_, "type": type_}
+    return {"data": data_, "type": type_, "diagnostic": diagnostic}
 
 
 def send_value(stream, value):

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -17,6 +17,7 @@ command line. The schema will be printed to stdout. This can be used to generate
 classes for implementations in other configs.
 """
 import copy
+import inspect
 import json
 import logging
 import math
@@ -157,6 +158,7 @@ class SpecialNumbers(StrEnum):
 class NumberType(WithFeatures, WithFunctions):
     type: NumericTypes
     data: Union[SpecialNumbers, Decimal, int, float]
+    diagnostic: Literal[None] = None  # Unused in this type.
 
     def get_used_features(self) -> FeatureSet:
         return FeatureSet(set(), {self.type}, _get_self_nested_type(self.type))
@@ -187,6 +189,12 @@ class StringType(WithFeatures, WithFunctions):
     type: StringTypes
     data: str
 
+    # Optional string representation of the type of the value, if the type is
+    # "unknown". TESTed will not do anything with this, as the actual type is
+    # unknown, but it will be shown to the user to aid them in debugging their
+    # error.
+    diagnostic: Optional[str] = None
+
     def get_used_features(self) -> FeatureSet:
         return FeatureSet(set(), {self.type}, _get_self_nested_type(self.type))
 
@@ -198,6 +206,7 @@ class StringType(WithFeatures, WithFunctions):
 class BooleanType(WithFeatures, WithFunctions):
     type: BooleanTypes
     data: bool
+    diagnostic: Literal[None] = None  # Unused in this type.
 
     def get_used_features(self) -> FeatureSet:
         return FeatureSet(set(), {self.type}, _get_self_nested_type(self.type))
@@ -210,6 +219,7 @@ class BooleanType(WithFeatures, WithFunctions):
 class SequenceType(WithFeatures, WithFunctions):
     type: SequenceTypes
     data: List["Expression"]
+    diagnostic: Literal[None] = None  # Unused in this type.
 
     def get_used_features(self) -> FeatureSet:
         nested_features = [x.get_used_features() for x in self.data]
@@ -272,6 +282,7 @@ class ObjectKeyValuePair(WithFeatures, WithFunctions):
 class ObjectType(WithFeatures, WithFunctions):
     type: ObjectTypes
     data: List[ObjectKeyValuePair]
+    diagnostic: Literal[None] = None  # Unused in this type.
 
     def get_key_type(self) -> WrappedAllTypes:
         """
@@ -307,6 +318,7 @@ class ObjectType(WithFeatures, WithFunctions):
 class NothingType(WithFeatures, WithFunctions):
     type: NothingTypes = BasicNothingTypes.NOTHING
     data: Literal[None] = None
+    diagnostic: Literal[None] = None  # Unused in this type.
 
     def get_used_features(self) -> FeatureSet:
         return FeatureSet(set(), {self.type}, _get_self_nested_type(self.type))
@@ -555,7 +567,7 @@ class PrintingDecimal:
 def _convert_to_python(value: Optional[Value], for_printing=False) -> Any:
     """
     Convert the parsed values into the proper Python type. This is basically
-    the same as de-serialising a value, but this function is currently not re-used
+    the same as deserialising a value, but this function is currently not re-used
     in the Python implementation, since run-time de-serialisation is not supported.
     :param value: The parsed value.
     :param for_printing: If the result will be used for printing or not.

--- a/tested/utils.py
+++ b/tested/utils.py
@@ -69,24 +69,6 @@ def basename(file: Union[str, Path]) -> str:
     return file.stem
 
 
-T = TypeVar("T")
-
-
-class Either(Generic[T]):
-    def __init__(self, value: Union[T, Exception]):
-        self.value = value
-
-    def get(self) -> T:
-        if isinstance(self.value, Exception):
-            raise self.value
-        return self.value
-
-    def maybe(self) -> Optional[T]:
-        if isinstance(self.value, Exception):
-            return None
-        return self.value
-
-
 def get_identifier() -> str:
     """Generate a random secret valid in most configs."""
     letter = random.choice(string.ascii_letters)
@@ -132,6 +114,7 @@ def consume_shebang(submission: Path) -> Optional[str]:
 
 K = TypeVar("K")
 V = TypeVar("V")
+T = TypeVar("T")
 
 
 class _FallbackDict(dict, Generic[K, V]):

--- a/tests/exercises/echo-function/solution/unknown-return-type.cs
+++ b/tests/exercises/echo-function/solution/unknown-return-type.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+public struct Coords
+{
+    public Coords(double x, double y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public double X { get; }
+    public double Y { get; }
+
+    public override string ToString() => $"({X}, {Y})";
+}
+
+class Submission
+{
+    public static Coords Echo(string content)
+    {
+        return new Coords(5.5, 7.5);
+    }
+}

--- a/tests/exercises/echo-function/solution/unknown-return-type.java
+++ b/tests/exercises/echo-function/solution/unknown-return-type.java
@@ -1,0 +1,8 @@
+record Coord (int x, int y) {}
+
+class Submission {
+
+    public static Coord echo(String value) {
+        return new Coord(5, 7);
+    }
+}

--- a/tests/exercises/echo-function/solution/unknown-return-type.js
+++ b/tests/exercises/echo-function/solution/unknown-return-type.js
@@ -1,0 +1,11 @@
+class Coord {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+    }
+
+}
+
+function echo(content) {
+    return new Coord(5, 7);
+}

--- a/tests/exercises/echo-function/solution/unknown-return-type.kt
+++ b/tests/exercises/echo-function/solution/unknown-return-type.kt
@@ -1,0 +1,6 @@
+data class Coord(val x: Int, val y: Int)
+
+
+fun echo(content : Any?) : Any? {
+    return Coord(5, 6);
+}

--- a/tests/exercises/echo-function/solution/unknown-return-type.py
+++ b/tests/exercises/echo-function/solution/unknown-return-type.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Coord:
+    x: int
+    y: int
+
+
+def echo(content):
+    return Coord(5, 6)

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -919,3 +919,30 @@ def test_function_arguments_without_brackets(tmp_path: Path, pytestconfig):
         result
         == f'{submission_name(bundle.lang_config)}.test 5.5 :: Double "hallo" True'
     )
+
+
+@pytest.mark.parametrize(
+    "language_and_expected",
+    [
+        ("csharp", '(Coords) {"X":5.5,"Y":7.5}'),
+        ("java", "Coord[x=5, y=7]"),
+        ("javascript", '(Coord) {"x":5,"y":7}'),
+        ("kotlin", "Coord(x=5, y=6)"),
+        ("python", "(<class 'submission.Coord'>) Coord(x=5, y=6)"),
+    ],
+)
+def test_unknown_return_type(tmp_path: Path, pytestconfig, language_and_expected):
+    language, expected = language_and_expected
+    conf = configuration(
+        pytestconfig,
+        "echo-function",
+        language,
+        tmp_path,
+        "one.tson",
+        "unknown-return-type",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["wrong"]
+    received_data = updates.find_next("close-test")["generated"]
+    assert received_data == expected


### PR DESCRIPTION
Currently, if a non-supported type is returned (i.e. a custom class or something TESTed doesn't support) we will show useless results to students.

For example, in the example from #355, the student implemented a property as a function, meaning the "return value" for the property call is a `Function` object. Currently, we report `{"type":"unknown"}` with a message `Received {"type":"unknown"}, which caused Could not find valid type for {"type":"unknown"}. for get_values.`. The reported return value and message are TESTed internals that should not be reported.

This is not very clear for students. In this PR, this is improved by attempting to show a useful string representation of the returned value (students can then compare this against the expected value), and if the string representation does not contain the type name (e.g. as with JavaScript), the type is also shown.

For the same example, the return value would be shown as `[object Function]`, without any message. While the example is in JavaScript, this was implemented for all OOP languages we currently support.

- Also add tests for this.
- Also clean up some related code.

Fixes #355.