### PR TITLE
Disable C0303 in Pylint

### DIFF
--- a/tested/languages/python/pylint_config.rc
+++ b/tested/languages/python/pylint_config.rc
@@ -9,5 +9,6 @@
 # C0103 Invalid name %r
 # C0111 Missing docstring
 # C0301 Line too long
+# C0303 Trailing whitespace
 # I0011 Warning locally suppressed using disable-msg
-disable=W0621,W0622,R0902,R0903,R0904,R0911,C0103,C0111,C0301,I0011
+disable=W0621,W0622,R0902,R0903,R0904,R0911,C0103,C0111,C0301,C0303,I0011


### PR DESCRIPTION
Fixes #375 

(Ignore the commit message, I accidentally first pushed this to master directly, which I then reverted)