### PR TITLE
Support advanced "null" type

### DIFF
--- a/tested/datatypes/advanced.py
+++ b/tested/datatypes/advanced.py
@@ -99,6 +99,11 @@ class AdvancedNothingTypes(_AdvancedDataType):
     Distinguish between undefined values and null values.
     Like in JavaScript.
     """
+    NULL = "null", BasicNothingTypes.NOTHING
+    """
+    Type to explicitly and exclusively denote the "null" type, but
+    not the "undefined" type, as the basic "nothing" type does.
+    """
 
 
 AdvancedTypes = Union[

--- a/tested/evaluators/value.py
+++ b/tested/evaluators/value.py
@@ -232,9 +232,13 @@ def evaluate(
     py_actual = to_python_comparable(actual)
 
     content_check = py_expected == py_actual
+    correct = type_check and content_check
 
-    # Only add the message about the type if the content is the same.
-    if content_check and not type_check:
+    if is_multiline_string:
+        readable_actual = get_as_string(actual, readable_actual)
+
+    # If the displayed values are the same, add a message about the type.
+    if not type_check and readable_expected == readable_actual:
         type_status = get_i18n_string("evaluators.value.datatype.wrong")
         messages.append(
             get_i18n_string(
@@ -243,11 +247,6 @@ def evaluate(
                 actual=actual.type,
             )
         )
-
-    correct = type_check and content_check
-
-    if is_multiline_string:
-        readable_actual = get_as_string(actual, readable_actual)
 
     return EvaluationResult(
         result=StatusMessage(

--- a/tested/languages/c/config.py
+++ b/tested/languages/c/config.py
@@ -52,6 +52,7 @@ class C(Language):
             "boolean": "supported",
             "nothing": "supported",
             "undefined": "reduced",
+            "null": "reduced",
             "int8": "reduced",
             "uint8": "reduced",
             "int16": "supported",

--- a/tested/languages/config.py
+++ b/tested/languages/config.py
@@ -221,7 +221,7 @@ class Language(ABC):
 
         :return: The features supported by this language.
         """
-        return {}
+        return set()
 
     def map_type_restrictions(self) -> Optional[Set[ExpressionTypes]]:
         """

--- a/tested/languages/csharp/config.py
+++ b/tested/languages/csharp/config.py
@@ -72,6 +72,8 @@ class CSharp(Language):
             "set": "supported",
             "map": "supported",
             "nothing": "supported",
+            "undefined": "reduced",
+            "null": "reduced",
             "int8": "supported",
             "uint8": "supported",
             "int16": "supported",

--- a/tested/languages/haskell/config.py
+++ b/tested/languages/haskell/config.py
@@ -50,6 +50,7 @@ class Haskell(Language):
             "sequence": "supported",
             "nothing": "supported",
             "undefined": "reduced",
+            "null": "reduced",
             "int8": "supported",
             "uint8": "supported",
             "int16": "supported",

--- a/tested/languages/java/config.py
+++ b/tested/languages/java/config.py
@@ -66,6 +66,7 @@ class Java(Language):
             "map": "supported",
             "nothing": "supported",
             "undefined": "reduced",
+            "null": "reduced",
             "int8": "supported",
             "uint8": "reduced",
             "int16": "supported",

--- a/tested/languages/javascript/config.py
+++ b/tested/languages/javascript/config.py
@@ -68,6 +68,7 @@ class JavaScript(Language):
             "map": "supported",
             "nothing": "supported",
             "undefined": "supported",
+            "null": "supported",
             "int8": "reduced",
             "uint8": "reduced",
             "int16": "reduced",

--- a/tested/languages/kotlin/config.py
+++ b/tested/languages/kotlin/config.py
@@ -75,6 +75,8 @@ class Kotlin(Language):
             "set": "supported",
             "map": "supported",
             "nothing": "supported",
+            "undefined": "reduced",
+            "null": "reduced",
             "int8": "supported",
             "uint8": "supported",
             "int16": "supported",
@@ -91,7 +93,6 @@ class Kotlin(Language):
             "array": "supported",
             "list": "supported",
             "tuple": "reduced",
-            "undefined": "reduced",
         }
 
     def map_type_restrictions(self) -> Optional[Set[ExpressionTypes]]:

--- a/tested/languages/python/config.py
+++ b/tested/languages/python/config.py
@@ -70,6 +70,7 @@ class Python(Language):
             "map": "supported",
             "nothing": "supported",
             "undefined": "reduced",
+            "null": "reduced",
             "int8": "reduced",
             "uint8": "reduced",
             "int16": "reduced",


### PR DESCRIPTION
This allows us to enforce "null" in JavaScript, without accepting "undefined".

This is pretty JavaScript-specific, but so is the "undefined" type, and one of the desired features of the whole basic/advanced system is to support cases like this.

For example, to enforce `null` and not ` undefined` in the DSL, you must cast the value (otherwise both `null` and `undefined` will be accepted):

```yaml
- tab: "Test tab"
  testcases:
    - expression: 'some_function()'
      return_raw: 'null(None)'
```