### PR TITLE
Fix linked stacktraces

### DIFF
--- a/tested/languages/utils.py
+++ b/tested/languages/utils.py
@@ -115,11 +115,12 @@ def executable_name(basename: str) -> str:
 
 
 def _convert_stacktrace_to_html(stacktrace: str) -> ExtendedMessage:
+    code_regex_escaped = r"&lt;code&gt;:(\d+)"
     link_replacement = r'<a href="#" class="tab-link" data-tab="code" data-line="\1">&lt;code&gt;:\1</a>'
     # Escape special characters.
     stacktrace = html.escape(stacktrace)
     # Add links to code.
-    stacktrace = re.sub(code_regex, link_replacement, stacktrace)
+    stacktrace = re.sub(code_regex_escaped, link_replacement, stacktrace)
     # We cannot generate a "pre" element, since that is ugly.
     generated = f"<div class='code'>{stacktrace.strip()}</div>"
     # Ensure newlines.

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -6,20 +6,23 @@ from tested.configs import DodonaConfig, GlobalConfig
 from tested.languages import LANGUAGES, Language
 
 # noinspection PyProtectedMember
-from tested.languages.utils import _replace_code_line_number
+from tested.languages.utils import (
+    _convert_stacktrace_to_html,
+    _replace_code_line_number,
+)
 from tested.testsuite import Suite
 
 
-def get_language(workdir: Path, language: str) -> Language:
+def get_language(workdir: str, language: str) -> Language:
     dodona_config = DodonaConfig(
-        resources="",
-        source="",
+        resources=Path(),
+        source=Path(),
         time_limit=0,
         memory_limit=0,
         natural_language="nl",
         programming_language=language,
-        workdir=workdir,
-        judge="",
+        workdir=Path(workdir),
+        judge=Path(),
     )
     global_config = GlobalConfig(
         dodona=dodona_config,
@@ -351,4 +354,22 @@ def test_code_link_line_number_replacement_works(tmp_path: Path, pytestconfig):
     at Codeersleutel.decodeer (<code>:103:18)
     """
     actual = _replace_code_line_number(5, stacktrace)
+    assert actual == expected
+
+
+def test_code_is_linked():
+    stacktrace = """AssertionError [ERR_ASSERTION]: ongeldig bericht
+    at bigram2letter (<code>:86:13)
+    at <code>:98:32
+    at Array.map (<anonymous>)
+    at Codeersleutel.decodeer (<code>:98:18)
+    """
+    expected = (
+        "<div class='code'>AssertionError [ERR_ASSERTION]: ongeldig bericht<br>"
+        '    at bigram2letter (<a href="#" class="tab-link" data-tab="code" data-line="86">&lt;code&gt;:86</a>:13)<br>'
+        '    at <a href="#" class="tab-link" data-tab="code" data-line="98">&lt;code&gt;:98</a>:32<br>'
+        "    at Array.map (&lt;anonymous&gt;)<br>"
+        '    at Codeersleutel.decodeer (<a href="#" class="tab-link" data-tab="code" data-line="98">&lt;code&gt;:98</a>:18)</div>'
+    )
+    actual = _convert_stacktrace_to_html(stacktrace).description
     assert actual == expected


### PR DESCRIPTION
Stacktraces were no linger linked to the code. This due to the regex not using escaped HTML characters, while it was applied after the stacktrace is already escaped.

Fixes #387.