### PR TITLE
Add support for custom checks in DSL

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,19 +2,17 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1678957337,
-        "narHash": "sha256-Gw4nVbuKRdTwPngeOZQOzH/IFowmz4LryMPDiJN/ah4=",
+        "lastModified": 1688380630,
+        "narHash": "sha256-8ilApWVb1mAi4439zS3iFeIT0ODlbrifm/fegWwgHjA=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "3e0e60ab37cd0bf7ab59888f5c32499d851edb47",
+        "rev": "f9238ec3d75cefbb2b42a44948c4e8fb1ae9a205",
         "type": "github"
       },
       "original": {
@@ -25,14 +23,14 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -63,11 +61,11 @@
         "pypi-deps-db": "pypi-deps-db"
       },
       "locked": {
-        "lastModified": 1681814846,
-        "narHash": "sha256-IMQ1Twf/ozE53CwrunXNlYD3D31xqgz/mZyZG38Ov/Y=",
+        "lastModified": 1689108475,
+        "narHash": "sha256-Tg8mLKfgIigFSA6IodqSaxjfYVZ0xELqUDtGJhsdN6g=",
         "owner": "DavHau",
         "repo": "mach-nix",
-        "rev": "8d903072c7b5426d90bc42a008242c76590af916",
+        "rev": "725aab8d52eb2f5b8ff67bea61049011ef31597c",
         "type": "github"
       },
       "original": {
@@ -92,11 +90,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681737997,
-        "narHash": "sha256-pHhjgsIkRMu80LmVe8QoKIZB6VZGRRxFmIvsC5S89k4=",
+        "lastModified": 1689534811,
+        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
+        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
         "type": "github"
       },
       "original": {
@@ -109,11 +107,11 @@
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1678051695,
-        "narHash": "sha256-kFFP8TN8pEKARtjK9loGdH+TU23ZbHdVLCUdNcufKPs=",
+        "lastModified": 1685526402,
+        "narHash": "sha256-V0SXx0dWlUBL3E/wHWTszrkK2dOnuYYnBc7n6e0+NQU=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "e00b22ead9d3534ba1c448e1af3076af6b234acf",
+        "rev": "ba35683c35218acb5258b69a9916994979dc73a9",
         "type": "github"
       },
       "original": {
@@ -131,6 +129,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -1,152 +1,154 @@
 {
-  "$id": "https://github.com/dodona-edu/universal-judge/blob/master/tested/dsl/schema.yaml",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "DSL Schema",
-  "description": "DSL test suite for TESTed",
-  "oneOf": [
+  "$id" : "https://github.com/dodona-edu/universal-judge/blob/master/tested/dsl/schema.yaml",
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "DSL Schema",
+  "description" : "DSL test suite for TESTed",
+  "oneOf" : [
     {
-      "$ref": "#/definitions/_rootObject"
+      "$ref" : "#/definitions/_rootObject"
     },
     {
-      "$ref": "#/definitions/tab"
+      "$ref" : "#/definitions/tab"
     },
     {
-      "$ref": "#/definitions/_tabList"
+      "$ref" : "#/definitions/_tabList"
     }
   ],
-  "definitions": {
-    "_tabList": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/tab"
+  "definitions" : {
+    "_tabList" : {
+      "type" : "array",
+      "minItems" : 1,
+      "items" : {
+        "$ref" : "#/definitions/tab"
       }
     },
-    "_contextList": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/context"
+    "_contextList" : {
+      "type" : "array",
+      "minItems" : 1,
+      "items" : {
+        "$ref" : "#/definitions/context"
       }
     },
-    "_testcaseList": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/testcase"
+    "_testcaseList" : {
+      "type" : "array",
+      "minItems" : 1,
+      "items" : {
+        "$ref" : "#/definitions/testcase"
       }
     },
-    "_rootObject": {
-      "type": "object",
-      "properties": {
-        "config": {
-          "$ref": "#/definitions/globalConfig",
-          "description": "Configuration applicable to the whole test suite."
+    "_rootObject" : {
+      "type" : "object",
+      "properties" : {
+        "config" : {
+          "$ref" : "#/definitions/globalConfig",
+          "description" : "Configuration applicable to the whole test suite."
         },
-        "namespace": {
-          "type": "string",
-          "description": "Namespace of the submitted solution, in `snake_case`"
+        "namespace" : {
+          "type" : "string",
+          "description" : "Namespace of the submitted solution, in `snake_case`"
         },
-        "tabs": {
-          "$ref": "#/definitions/_tabList"
+        "tabs" : {
+          "$ref" : "#/definitions/_tabList"
         }
       },
-      "required": [
+      "required" : [
         "tabs"
       ]
     },
-    "tab": {
-      "type": "object",
-      "properties": {
-        "config": {
-          "$ref": "#/definitions/globalConfig",
-          "description": "Configuration applicable to this tab"
+    "tab" : {
+      "type" : "object",
+      "properties" : {
+        "config" : {
+          "$ref" : "#/definitions/globalConfig",
+          "description" : "Configuration applicable to this tab"
         },
-        "hidden": {
-          "type": "boolean",
-          "description": "Defines if the tab is hidden for the student or not"
+        "hidden" : {
+          "type" : "boolean",
+          "description" : "Defines if the tab is hidden for the student or not"
         },
-        "tab": {
-          "type": "string",
-          "description": "The name of this tab."
+        "tab" : {
+          "type" : "string",
+          "description" : "The name of this tab."
         },
-        "contexts": {
-          "$ref": "#/definitions/_contextList"
+        "contexts" : {
+          "$ref" : "#/definitions/_contextList"
         },
-        "testcases": {
-          "$ref": "#/definitions/_testcaseList"
+        "testcases" : {
+          "$ref" : "#/definitions/_testcaseList"
         }
       },
-      "oneOf": [
+      "oneOf" : [
         {
-          "required": [
+          "required" : [
             "contexts",
             "tab"
           ]
         },
         {
-          "required": [
+          "required" : [
             "testcases",
             "tab"
           ]
         }
       ]
     },
-    "context": {
-      "type": "object",
-      "properties": {
-        "config": {
-          "$ref": "#/definitions/globalConfig",
-          "description": "Configuration settings at context level"
+    "context" : {
+      "type" : "object",
+      "properties" : {
+        "config" : {
+          "$ref" : "#/definitions/globalConfig",
+          "description" : "Configuration settings at context level"
         },
-        "context": {
-          "type": "string",
-          "description": "Description of this context."
+        "context" : {
+          "type" : "string",
+          "description" : "Description of this context."
         },
-        "testcases": {
-          "$ref": "#/definitions/_testcaseList"
+        "testcases" : {
+          "$ref" : "#/definitions/_testcaseList"
         }
       },
-      "required": [
+      "required" : [
         "testcases"
       ]
     },
-    "testcase": {
-      "type": "object",
-      "description": "An individual test for a statement or expression",
-      "properties": {
-        "exception": {
-          "description": "Expected exception message",
+    "testcase" : {
+      "type" : "object",
+      "description" : "An individual test for a statement or expression",
+      "properties" : {
+        "exception" : {
+          "description" : "Expected exception message",
           "oneOf" : [
             {
-              "$ref": "#/definitions/generalOutput"
+              "type" : "string"
             },
             {
               "type" : "object",
-              "required" : ["types"],
+              "required" : [
+                "types"
+              ],
               "properties" : {
-                "message": {
-                  "$ref": "#/definitions/generalOutput"
+                "message" : {
+                  "type" : "string"
                 },
-                "types": {
+                "types" : {
                   "type" : "object",
-                  "items": {
-                    "type": "string"
+                  "items" : {
+                    "type" : "string"
                   }
                 }
               }
             }
           ]
         },
-        "files": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/file"
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/file"
           }
         },
-        "return": {
-          "description": "Expected return value",
-          "type": [
+        "return" : {
+          "description" : "Expected return value",
+          "type" : [
             "array",
             "boolean",
             "integer",
@@ -156,166 +158,271 @@
             "string"
           ]
         },
-        "return_raw": {
-          "description": "Value string to parse to the expected return value",
-          "$ref": "#/definitions/generalOutput"
+        "return_raw" : {
+          "description" : "Value string to parse to the expected return value",
+          "$ref" : "#/definitions/advancedValueOutputChannel"
         },
-        "statement": {
-          "description": "Statement or expression to evaluate",
-          "$ref": "#/definitions/textualTypes"
+        "statement" : {
+          "description" : "Statement or expression to evaluate",
+          "type" : "string"
         },
-        "expression": {
-          "description": "Statement or expression to evaluate",
-          "$ref": "#/definitions/textualTypes"
+        "expression" : {
+          "description" : "Statement or expression to evaluate",
+          "type" : "string"
         },
-        "stderr": {
-          "description": "Expected output at stderr",
-          "$ref": "#/definitions/streamOutput"
+        "stderr" : {
+          "description" : "Expected output at stderr",
+          "$ref" : "#/definitions/textOutputChannel"
         },
-        "stdout": {
-          "description": "Expected output at stdout",
-          "$ref": "#/definitions/streamOutput"
+        "stdout" : {
+          "description" : "Expected output at stdout",
+          "$ref" : "#/definitions/textOutputChannel"
         },
-        "config": {
-          "$ref": "#/definitions/globalConfig",
-          "description": "Configuration settings at testcase level"
+        "config" : {
+          "$ref" : "#/definitions/globalConfig",
+          "description" : "Configuration settings at testcase level"
         },
-        "stdin": {
-          "description": "Stdin for this context",
-          "$ref": "#/definitions/textualTypes"
+        "stdin" : {
+          "description" : "Stdin for this context",
+          "type" : [
+            "string",
+            "number",
+            "integer",
+            "boolean"
+          ]
         },
-        "exitCode": {
-          "type": "integer",
-          "description": "Expected exit code for the run"
+        "exitCode" : {
+          "type" : "integer",
+          "description" : "Expected exit code for the run"
         },
-        "arguments": {
-          "type": "array",
-          "description": "Array of program call arguments",
-          "items": {
-            "$ref": "#/definitions/textualTypes"
+        "arguments" : {
+          "type" : "array",
+          "description" : "Array of program call arguments",
+          "items" : {
+            "type" : [
+              "string",
+              "number",
+              "integer",
+              "boolean"
+            ]
           }
         }
       }
     },
-    "configText": {
-      "type": "object",
-      "description": "Configuration properties for textual comparison and to configure if the expected value should be hidden or not",
-      "minProperties": 1,
-      "properties": {
-        "applyRounding": {
-          "description": "Apply rounding when comparing as float",
-          "type": "boolean"
-        },
-        "caseInsensitive": {
-          "description": "Ignore case when comparing strings",
-          "type": "boolean"
-        },
-        "ignoreWhitespace": {
-          "description": "Ignore leading and trailing whitespace",
-          "type": "boolean"
-        },
-        "roundTo": {
-          "description": "The number of decimals to round at, when applying the rounding on floats",
-          "type": "integer"
-        },
-        "tryFloatingPoint": {
-          "description": "Try comparing text as floating point numbers",
-          "type": "boolean"
-        },
-        "hideExpected": {
-          "description": "Hide the expected value in feedback (default: false), not recommended to use!",
-          "type": "boolean"
-        }
-      }
-    },
-    "localConfigGeneral": {
-      "type": "object",
-      "description": "General configuration properties for one test",
-      "required": [
-        "data"
-      ],
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/textualTypes"
-        }
-      }
-    },
-    "localConfigText": {
-      "type": "object",
-      "description": "Textual configuration properties of one test",
-      "required": [
-        "data",
-        "config"
-      ],
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/textualTypes"
-        },
-        "config": {
-          "$ref": "#/definitions/configText"
-        }
-      }
-    },
-    "globalConfig": {
-      "type": "object",
-      "description": "Global configuration properties",
-      "minProperties": 1,
-      "properties": {
-        "stdout": {
-          "$ref": "#/definitions/configText"
-        },
-        "stderr": {
-          "$ref": "#/definitions/configText"
-        }
-      }
-    },
-    "streamOutput": {
-      "anyOf": [
+    "textOutputChannel" : {
+      "anyOf" : [
         {
-          "$ref": "#/definitions/textualTypes"
+          "description" : "A simple value which is converted into a string.",
+          "type" : [
+            "string",
+            "number",
+            "integer",
+            "boolean"
+          ]
         },
         {
-          "$ref": "#/definitions/localConfigText"
+          "$ref" : "#/definitions/advancedTextOutputChannel"
         }
       ]
     },
-    "generalOutput": {
-      "$ref": "#/definitions/textualTypes"
+    "advancedTextOutputChannel" : {
+      "type" : "object",
+      "description" : "Advanced output for a text output channel, such as stdout or stderr.",
+      "required" : [
+        "data"
+      ],
+      "properties" : {
+        "data" : {
+          "description" : "The expected data types.",
+          "type" : [
+            "string",
+            "number",
+            "integer",
+            "boolean"
+          ]
+        },
+        "config" : {
+          "$ref" : "#/definitions/textConfigurationOptions"
+        }
+      },
+      "oneOf" : [
+        {
+          "properties" : {
+            "evaluator" : {
+              "type" : "string",
+              "enum" : [
+                "builtin"
+              ]
+            }
+          }
+        },
+        {
+          "required" : [
+            "evaluator",
+            "language",
+            "file"
+          ],
+          "properties" : {
+            "evaluator" : {
+              "type" : "string",
+              "enum" : [
+                "custom"
+              ]
+            },
+            "language" : {
+              "type" : "string",
+              "description" : "The programming language of the custom check function."
+            },
+            "file" : {
+              "type" : "string",
+              "description" : "The path to the file containing the custom check function."
+            },
+            "name" : {
+              "type" : "string",
+              "description" : "The name of the custom check function.",
+              "default" : "evaluate"
+            },
+            "arguments" : {
+              "type" : "array",
+              "description" : "List of 'Python' values to use as arguments to the function.",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      ]
     },
-    "file": {
-      "type": "object",
-      "description": "Tab definition with testcases",
-      "required": [
+    "advancedValueOutputChannel" : {
+      "oneOf" : [
+        {
+          "type" : "string",
+          "description" : "A 'Python' value to parse and use as the expected type."
+        },
+        {
+          "type" : "object",
+          "description" : "A custom check function.",
+          "required" : [
+            "value"
+          ],
+          "properties" : {
+            "value" : {
+              "type" : "string",
+              "description" : "The expected value."
+            }
+          },
+          "oneOf" : [
+            {
+              "properties" : {
+                "evaluator" : {
+                  "type" : "string",
+                  "enum" : [
+                    "builtin"
+                  ]
+                }
+              }
+            },
+            {
+              "required" : [
+                "evaluator",
+                "language",
+                "file"
+              ],
+              "properties" : {
+                "evaluator" : {
+                  "type" : "string",
+                  "enum" : [
+                    "custom"
+                  ]
+                },
+                "language" : {
+                  "type" : "string",
+                  "description" : "The programming language of the custom check function."
+                },
+                "file" : {
+                  "type" : "string",
+                  "description" : "The path to the file containing the custom check function."
+                },
+                "name" : {
+                  "type" : "string",
+                  "description" : "The name of the custom check function.",
+                  "default" : "evaluate"
+                },
+                "arguments" : {
+                  "type" : "array",
+                  "description" : "List of 'Python' values to use as arguments to the function.",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "textConfigurationOptions" : {
+      "type" : "object",
+      "description" : "Configuration properties for textual comparison and to configure if the expected value should be hidden or not",
+      "minProperties" : 1,
+      "properties" : {
+        "applyRounding" : {
+          "description" : "Apply rounding when comparing as float",
+          "type" : "boolean"
+        },
+        "caseInsensitive" : {
+          "description" : "Ignore case when comparing strings",
+          "type" : "boolean"
+        },
+        "ignoreWhitespace" : {
+          "description" : "Ignore leading and trailing whitespace",
+          "type" : "boolean"
+        },
+        "roundTo" : {
+          "description" : "The number of decimals to round at, when applying the rounding on floats",
+          "type" : "integer"
+        },
+        "tryFloatingPoint" : {
+          "description" : "Try comparing text as floating point numbers",
+          "type" : "boolean"
+        },
+        "hideExpected" : {
+          "description" : "Hide the expected value in feedback (default: false), not recommended to use!",
+          "type" : "boolean"
+        }
+      }
+    },
+    "globalConfig" : {
+      "type" : "object",
+      "description" : "Global configuration properties",
+      "minProperties" : 1,
+      "properties" : {
+        "stdout" : {
+          "$ref" : "#/definitions/textConfigurationOptions"
+        },
+        "stderr" : {
+          "$ref" : "#/definitions/textConfigurationOptions"
+        }
+      }
+    },
+    "file" : {
+      "type" : "object",
+      "description" : "Path to a file for input.",
+      "required" : [
         "name",
         "url"
       ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "File name"
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "description" : "File name"
         },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Relative path to the file in the `description` folder of a Dodona exercise"
+        "url" : {
+          "type" : "string",
+          "format" : "uri",
+          "description" : "Relative path to the file in the `description` folder of a Dodona exercise"
         }
       }
-    },
-    "textualTypes": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "string"
-        }
-      ]
     }
   }
 }

--- a/tested/testsuite.py
+++ b/tested/testsuite.py
@@ -156,6 +156,17 @@ class TextChannelType(StrEnum):
     FILE = "file"  # Path to a file
 
 
+def _resolve_path(working_directory, file_path):
+    """
+    Resolve a path to an absolute path. Relative paths will be resolved against
+    the given ``directory``, not the actual working directory.
+    """
+    if path.isabs(file_path):
+        return path.abspath(file_path)
+    else:
+        return path.abspath(path.join(working_directory, file_path))
+
+
 @dataclass
 class TextData(WithFeatures):
     """Describes textual data: either directly or in a file."""
@@ -163,23 +174,12 @@ class TextData(WithFeatures):
     data: str
     type: TextChannelType = TextChannelType.TEXT
 
-    @staticmethod
-    def _resolve_path(working_directory, file_path):
-        """
-        Resolve a path to an absolute path. Relative paths will be resolved against
-        the given ``directory``, not the actual working directory.
-        """
-        if path.isabs(file_path):
-            return path.abspath(file_path)
-        else:
-            return path.abspath(path.join(working_directory, file_path))
-
     def get_data_as_string(self, working_directory: Path) -> str:
         """Get the data as a string, reading the file if necessary."""
         if self.type == TextChannelType.TEXT:
             return self.data
         elif self.type == TextChannelType.FILE:
-            file_path = self._resolve_path(working_directory, self.data)
+            file_path = _resolve_path(working_directory, self.data)
             with open(file_path, "r") as file:
                 return file.read()
         else:
@@ -214,7 +214,7 @@ class FileOutputChannel(WithFeatures):
         return NOTHING
 
     def get_data_as_string(self, resources: Path) -> str:
-        file_path = self._resolve_path(resources, self.expected_path)
+        file_path = _resolve_path(resources, self.expected_path)
         with open(file_path, "r") as file:
             return file.read()
 


### PR DESCRIPTION
This adds support for custom checks in the DSL:

```yaml
- tab: 'Test'
  contexts:
    - testcases:
        - statement: 'test()'
          return_raw:
            value: "'hallo'"
            evaluator: "custom"
            language: "python"
            file: "test.py"
            name: "evaluate_test"
            arguments: ["'yes'", "5", "set([5, 5])"]
```

As a reminder, custom checks are available for textual output (e.g. stdout, stderr) and return values. For return values, only `return_raw` is supported (not `return`, as we cannot know if an object is a value or a custom check).

Fixes #391.
