### PR TITLE
Fix crash and add test

### DIFF
--- a/tested/evaluators/value.py
+++ b/tested/evaluators/value.py
@@ -1,7 +1,6 @@
 """
 Value evaluator.
 """
-import itertools
 import logging
 from typing import Optional, Tuple, Union, cast
 
@@ -198,9 +197,7 @@ def _check_data_type(
             prepared_actual.data if isinstance(prepared_actual.data, list) else []
         )
         prepared_elements = []
-        for expected_element, actual_element in itertools.zip_longest(
-            expected_elements, actual_elements
-        ):
+        for expected_element, actual_element in zip(expected_elements, actual_elements):
             assert expected_element is None or isinstance(expected_element, Value)
             assert actual_element is None or isinstance(actual_element, Value)
             element_valid, prepared_element = _check_data_type(
@@ -215,13 +212,11 @@ def _check_data_type(
             prepared_actual.data if isinstance(prepared_actual.data, list) else []
         )
         prepared_elements = []
-        for expected_element, actual_element in itertools.zip_longest(
-            expected_elements, actual_elements
-        ):
+        for expected_element, actual_element in zip(expected_elements, actual_elements):
             assert isinstance(actual_element, ObjectKeyValuePair)
             actual_key, actual_value = actual_element.key, actual_element.value
             assert isinstance(actual_key, Value) and isinstance(actual_value, Value)
-            expected_key, expected_value = actual_element.key, actual_element.value
+            expected_key, expected_value = expected_element.key, expected_element.value
             assert isinstance(expected_key, Value) and isinstance(expected_value, Value)
             key_valid, prepared_key = _check_data_type(bundle, expected_key, actual_key)
             value_valid, prepared_value = _check_data_type(

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -177,7 +177,8 @@ class NumberType(WithFeatures, WithFunctions):
                 f"real numbers."
             )
 
-        if resolve_to_basic(values.get("type")) == BasicNumericTypes.INTEGER:
+        type_ = values.get("type")
+        if type_ and resolve_to_basic(type_) == BasicNumericTypes.INTEGER:
             values["data"] = values["data"].to_integral_value()
 
         return values


### PR DESCRIPTION
In adding the types, we used `zip_longest`, which resulted in a crash if there were more values than expected in the test suite. This has been fixed to properly handle this.