### PR TITLE
Support YAML tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: sudo apt -y install hlint cppcheck shellcheck checkstyle
       - run: curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.48.2/ktlint && chmod a+x ktlint
       - run: echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
-      - run: pipenv run pytest -n auto --cov=tested tests/
+      - run: pipenv run pytest -n auto --cov=tested --cov-report=xml tests/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
   lint:

--- a/tested/dsl/ast_translator.py
+++ b/tested/dsl/ast_translator.py
@@ -30,7 +30,6 @@ import ast
 from decimal import Decimal
 from typing import Literal, Optional, cast, overload
 
-import attrs
 from attrs import evolve
 
 from tested.datatypes import (

--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -147,16 +147,7 @@
           }
         },
         "return" : {
-          "description" : "Expected return value",
-          "type" : [
-            "array",
-            "boolean",
-            "integer",
-            "null",
-            "number",
-            "object",
-            "string"
-          ]
+          "description" : "Expected return value"
         },
         "return_raw" : {
           "description" : "Value string to parse to the expected return value",

--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -129,6 +129,11 @@ def _convert_value(value: YamlObject) -> Value:
             type=BasicSequenceTypes.SEQUENCE,
             data=[_convert_value(part_value) for part_value in value],
         )
+    elif isinstance(value, set):
+        return SequenceType(
+            type=BasicSequenceTypes.SET,
+            data=[_convert_value(part_value) for part_value in value],
+        )
     else:
         data = []
         for key, val in value.items():
@@ -350,7 +355,7 @@ def parse_dsl(dsl_string: str, validate: bool = True) -> Suite:
     """
     dsl_object = _parse_yaml(dsl_string)
     if validate and not _validate_dsl(dsl_object):
-        raise ValueError("Cannot parse invalid DSL.")
+        raise ValueError("DSL does not adhere to the JSON schema")
     return _convert_dsl(dsl_object)
 
 

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -693,3 +693,32 @@ def test_value_custom_checks_correct():
             ],
         ),
     ]
+
+
+def test_yaml_set_tag_is_supported():
+    yaml_str = """
+- tab: 'Test'
+  contexts:
+    - testcases:
+        - statement: 'test()'
+          return: !!set {5, 6}
+    """
+    json_str = translate_to_test_suite(yaml_str)
+    suite = parse_test_suite(json_str)
+    assert len(suite.tabs) == 1
+    tab = suite.tabs[0]
+    assert len(tab.contexts) == 1
+    testcases = tab.contexts[0].testcases
+    assert len(testcases) == 1
+    test = testcases[0]
+    assert isinstance(test.input, FunctionCall)
+    assert isinstance(test.output.result, ValueOutputChannel)
+    value = test.output.result.value
+    assert isinstance(value, SequenceType)
+    assert value == SequenceType(
+        type=BasicSequenceTypes.SET,
+        data=[
+            NumberType(type=BasicNumericTypes.INTEGER, data=5),
+            NumberType(type=BasicNumericTypes.INTEGER, data=6),
+        ],
+    )


### PR DESCRIPTION
This PR adds support for YAML tags in the DSL.

- We support the standard YAML `!!set` (fixes #401)
- We support all TESTed types via "local data types", meaning with a single exclamation mark: `!int64`, `!set`, ... (fixes #402)

For example:

```yaml
- tab: 'Test'
  contexts:
    - testcases:
        - statement: 'test()'
          return: !!set {5, 6}
```

Note that the return statement is not checked by the JSON Schema (as it is not capable of doing custom types), so if you put nonsense, it will crash with an exception somewhere (e.g. `!int64 [5, 6]` will result in a crash).