### PR TITLE
Support language-specific literals

### DIFF
--- a/tested/configs.py
+++ b/tested/configs.py
@@ -8,7 +8,7 @@ from typing import IO, TYPE_CHECKING, Any, Dict, Optional, Tuple
 from attrs import define, evolve, field
 
 from tested.parsing import fallback_field, get_converter
-from tested.testsuite import ExecutionMode, Suite
+from tested.testsuite import ExecutionMode, Suite, SupportedLanguage
 from tested.utils import consume_shebang, get_identifier, smart_close
 
 # Prevent circular imports
@@ -74,8 +74,7 @@ class DodonaConfig:
     time_limit: int
     memory_limit: int
     natural_language: str
-    programming_language: str
-    # noinspection SpellCheckingInspection
+    programming_language: SupportedLanguage
     workdir: Path
     judge: Path
     test_suite: str = (
@@ -147,7 +146,7 @@ class Bundle:
         return self.global_config.context_separator_secret
 
 
-def _get_language(config: DodonaConfig) -> Tuple[str, int]:
+def _get_language(config: DodonaConfig) -> Tuple[SupportedLanguage, int]:
     import tested.languages as langs
 
     bang = consume_shebang(config.source)

--- a/tested/descriptions/__init__.py
+++ b/tested/descriptions/__init__.py
@@ -7,7 +7,7 @@ from tested.descriptions.converters import (
     convert_tested_markdown,
 )
 from tested.languages import get_language
-from tested.testsuite import Suite
+from tested.testsuite import Suite, SupportedLanguage
 
 
 def process_problem_statement(
@@ -21,7 +21,7 @@ def process_problem_statement(
             time_limit=0,
             memory_limit=0,
             natural_language=natural_language,
-            programming_language=programming_language,
+            programming_language=SupportedLanguage(programming_language),
             workdir=Path(),
             judge=judge_directory,
         ),

--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -49,6 +49,18 @@
         },
         "tabs" : {
           "$ref" : "#/definitions/_tabList"
+        },
+        "language" : {
+          "description" : "Indicate that all code is in a specific language.",
+          "oneOf" : [
+            {
+              "$ref" : "#/definitions/supportedLanguage"
+            },
+            {
+              "const" : "tested"
+            }
+          ],
+          "default" : "tested"
         }
       },
       "required" : [
@@ -115,6 +127,35 @@
       "type" : "object",
       "description" : "An individual test for a statement or expression",
       "properties" : {
+        "stdin" : {
+          "description" : "Stdin for this context",
+          "type" : [
+            "string",
+            "number",
+            "integer",
+            "boolean"
+          ]
+        },
+        "arguments" : {
+          "type" : "array",
+          "description" : "Array of program call arguments",
+          "items" : {
+            "type" : [
+              "string",
+              "number",
+              "integer",
+              "boolean"
+            ]
+          }
+        },
+        "statement" : {
+          "description" : "The statement to evaluate.",
+          "$ref" : "#/definitions/expressionOrStatement"
+        },
+        "expression" : {
+          "description" : "The expression to evaluate.",
+          "$ref" : "#/definitions/expressionOrStatement"
+        },
         "exception" : {
           "description" : "Expected exception message",
           "oneOf" : [
@@ -132,6 +173,9 @@
                 },
                 "types" : {
                   "type" : "object",
+                  "propertyNames" : {
+                    "$ref" : "#/definitions/supportedLanguage"
+                  },
                   "items" : {
                     "type" : "string"
                   }
@@ -153,14 +197,6 @@
           "description" : "Value string to parse to the expected return value",
           "$ref" : "#/definitions/advancedValueOutputChannel"
         },
-        "statement" : {
-          "description" : "Statement or expression to evaluate",
-          "type" : "string"
-        },
-        "expression" : {
-          "description" : "Statement or expression to evaluate",
-          "type" : "string"
-        },
         "stderr" : {
           "description" : "Expected output at stderr",
           "$ref" : "#/definitions/textOutputChannel"
@@ -173,30 +209,9 @@
           "$ref" : "#/definitions/globalConfig",
           "description" : "Configuration settings at testcase level"
         },
-        "stdin" : {
-          "description" : "Stdin for this context",
-          "type" : [
-            "string",
-            "number",
-            "integer",
-            "boolean"
-          ]
-        },
         "exitCode" : {
           "type" : "integer",
           "description" : "Expected exit code for the run"
-        },
-        "arguments" : {
-          "type" : "array",
-          "description" : "Array of program call arguments",
-          "items" : {
-            "type" : [
-              "string",
-              "number",
-              "integer",
-              "boolean"
-            ]
-          }
         }
       }
     },
@@ -213,6 +228,23 @@
         },
         {
           "$ref" : "#/definitions/advancedTextOutputChannel"
+        }
+      ]
+    },
+    "expressionOrStatement" : {
+      "oneOf" : [
+        {
+          "type" : "string"
+        },
+        {
+          "type" : "object",
+          "propertyNames" : {
+            "$ref" : "#/definitions/supportedLanguage"
+          },
+          "items" : {
+            "type" : "string",
+            "description" : "A language-specific literal which will be used verbatim."
+          }
         }
       ]
     },
@@ -414,6 +446,20 @@
           "description" : "Relative path to the file in the `description` folder of a Dodona exercise"
         }
       }
+    },
+    "supportedLanguage" : {
+      "type" : "string",
+      "enum" : [
+        "bash",
+        "c",
+        "haskell",
+        "java",
+        "javascript",
+        "kotlin",
+        "python",
+        "runhaskell",
+        "csharp"
+      ]
     }
   }
 }

--- a/tested/features.py
+++ b/tested/features.py
@@ -40,13 +40,9 @@ class Construct(StrEnum):
     GLOBAL_VARIABLES = "global_variables"
 
 
-Types = Set[AllTypes]
-Constructs = Set[Construct]
-
-
 class FeatureSet(NamedTuple):
-    constructs: Constructs
-    types: Types
+    constructs: Set[Construct]
+    types: Set[AllTypes]
     nested_types: NestedTypes
 
 
@@ -153,11 +149,11 @@ def is_supported(language: "Language") -> bool:
         assert tab.contexts is not None
         for context in tab.contexts:
             for testcase in context.testcases:
-                languages = testcase.output.get_specific_languages()
+                languages = testcase.get_specific_languages()
                 if languages is not None:
                     if language.config.dodona.programming_language not in languages:
                         _logger.warning(
-                            f"Language-specific oracles are available only in "
+                            f"Language-specific constructs are available only in "
                             f"{languages}!"
                         )
                         return False

--- a/tested/features.py
+++ b/tested/features.py
@@ -153,7 +153,7 @@ def is_supported(language: "Language") -> bool:
         assert tab.contexts is not None
         for context in tab.contexts:
             for testcase in context.testcases:
-                languages = testcase.output.get_specific_oracle_languages()
+                languages = testcase.output.get_specific_languages()
                 if languages is not None:
                     if language.config.dodona.programming_language not in languages:
                         _logger.warning(

--- a/tested/internationalization/en.yaml
+++ b/tested/internationalization/en.yaml
@@ -1,11 +1,11 @@
 en:
-  evaluators:
+  oracles:
     exception:
       staff: >-
         Expected value exception, but received %{actual}, which caused an exception
         while parsing: %{exception}
       student: >-
-        Dodona don't understood this exception. Report this error to the teacher.
+        Dodona does not understand this exception. Report this error to the teacher.
       status: "Invalid exception"
     exitcode:
       status:

--- a/tested/internationalization/nl.yaml
+++ b/tested/internationalization/nl.yaml
@@ -1,5 +1,5 @@
 nl:
-  evaluators:
+  oracles:
     exception:
       staff: >-
         Verwachte een foutwaarde, maar %{actual} gekregen, welke een fout

--- a/tested/judge/evaluation.py
+++ b/tested/judge/evaluation.py
@@ -399,7 +399,7 @@ def should_show(test: OutputChannel, channel: Channel) -> bool:
         return not isinstance(test, IgnoredChannel)
     elif channel == Channel.RETURN:
         assert isinstance(test, ValueOutput)
-        # We don't show the channel if we ignore it or expect no result.
+        # We don't show the channel if we ignore it.
         return not isinstance(test, IgnoredChannel)
     elif channel == Channel.EXCEPTION:
         assert isinstance(test, ExceptionOutput)

--- a/tested/languages/__init__.py
+++ b/tested/languages/__init__.py
@@ -22,6 +22,7 @@ from tested.languages.runhaskell.config import RunHaskell
 if TYPE_CHECKING:
     from tested.configs import GlobalConfig
 
+
 LANGUAGES = {
     "bash": Bash,
     "c": C,

--- a/tested/languages/c/generators.py
+++ b/tested/languages/c/generators.py
@@ -187,7 +187,11 @@ def _generate_internal_context(ctx: PreparedContext, pu: PreparedExecutionUnit) 
             result += "exit_code = 0;\n"
             if is_special_void_call(tc.input, pu.language):
                 # The method has a "void" return type, so don't wrap it.
-                result += " " * 4 + convert_statement(tc.input.statement) + ";\n"
+                result += (
+                    " " * 4
+                    + convert_statement(tc.input.unwrapped_input_statement())
+                    + ";\n"
+                )
                 result += " " * 4 + convert_statement(tc.input.no_value_call()) + ";\n"
             else:
                 result += convert_statement(tc.input.input_statement()) + ";\n"

--- a/tested/languages/csharp/generators.py
+++ b/tested/languages/csharp/generators.py
@@ -298,7 +298,11 @@ def _generate_internal_context(ctx: PreparedContext, pu: PreparedExecutionUnit) 
             assert isinstance(tc.input, PreparedTestcaseStatement)
             if is_special_void_call(tc.input, pu.language):
                 # The method has a "void" return type, so don't wrap it.
-                result += " " * 4 + convert_statement(tc.input.statement) + ";\n"
+                result += (
+                    " " * 4
+                    + convert_statement(tc.input.unwrapped_input_statement())
+                    + ";\n"
+                )
                 result += " " * 4 + convert_statement(tc.input.no_value_call()) + ";\n"
             else:
                 result += (

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -45,6 +45,7 @@ from tested.testsuite import (
     Context,
     CustomCheckOracle,
     FileUrl,
+    LanguageLiterals,
     MainInput,
     Testcase,
     TextData,
@@ -147,12 +148,14 @@ def get_readable_input(
                 analyse_files = True
             else:
                 text = stdin
-    else:
-        assert isinstance(case.input, Statement)
+    elif isinstance(case.input, Statement):
         format_ = bundle.config.programming_language
         text = generate_statement(bundle, case.input)
         text = bundle.lang_config.cleanup_description(text)
         analyse_files = True
+    else:
+        assert isinstance(case.input, LanguageLiterals)
+        text = case.input.get_for(bundle.config.programming_language)
 
     quote = bundle.lang_config.get_string_quote()
     if not analyse_files or not files:

--- a/tested/languages/haskell/generators.py
+++ b/tested/languages/haskell/generators.py
@@ -35,6 +35,7 @@ from tested.serialisation import (
     as_basic_type,
 )
 from tested.testsuite import MainInput
+from tested.utils import is_statement_strict
 
 
 def convert_arguments(arguments: List[Expression]) -> str:
@@ -254,12 +255,17 @@ handleException (Right _) = Nothing
                 assert isinstance(tc.input, PreparedTestcaseStatement)
                 # In Haskell we do not actually have statements, so we need to keep them separate.
                 # Additionally, exceptions with "statements" are not supported at this time.
-                if not isinstance(tc.input.statement, Expression):
-                    result += indent + convert_statement(tc.input.statement) + "\n"
+                if is_statement_strict(tc.input.statement):
+                    result += (
+                        indent
+                        + convert_statement(tc.input.unwrapped_input_statement())
+                        + "\n"
+                    )
                 else:
                     result += indent + f"result{i1} <- catch\n"
                     result += (
-                        indent * 2 + f"({convert_statement(tc.input.statement, True)}\n"
+                        indent * 2
+                        + f"({convert_statement(tc.input.unwrapped_input_statement(), True)}\n"
                     )
                     id_result = tc.input.input_statement("r")
                     if isinstance(id_result, Identifier):

--- a/tested/languages/java/generators.py
+++ b/tested/languages/java/generators.py
@@ -291,7 +291,11 @@ def _generate_internal_context(ctx: PreparedContext, pu: PreparedExecutionUnit) 
             assert isinstance(tc.input, PreparedTestcaseStatement)
             if is_special_void_call(tc.input, pu.language):
                 # The method has a "void" return type, so don't wrap it.
-                result += " " * 4 + convert_statement(tc.input.statement) + ";\n"
+                result += (
+                    " " * 4
+                    + convert_statement(tc.input.unwrapped_input_statement())
+                    + ";\n"
+                )
                 result += " " * 4 + convert_statement(tc.input.no_value_call()) + ";\n"
             else:
                 result += (

--- a/tested/manual.py
+++ b/tested/manual.py
@@ -11,9 +11,9 @@ from pathlib import Path
 
 from tested.configs import DodonaConfig, Options
 from tested.main import run
-from tested.testsuite import ExecutionMode
+from tested.testsuite import ExecutionMode, SupportedLanguage
 
-exercise_dir = "/home/niko/Ontwikkeling/universal-judge/tests/exercises/counter"
+exercise_dir = "/home/niko/Ontwikkeling/universal-judge/tests/exercises/echo-function"
 
 
 def read_config() -> DodonaConfig:
@@ -21,13 +21,13 @@ def read_config() -> DodonaConfig:
     return DodonaConfig(
         memory_limit=536870912,
         time_limit=60,
-        programming_language="python",
+        programming_language=SupportedLanguage("haskell"),
         natural_language="nl",
         resources=Path(exercise_dir, "evaluation"),
-        source=Path(exercise_dir, "solution/solution.py"),
+        source=Path(exercise_dir, "solution/correct.hs"),
         judge=Path("."),
         workdir=Path("workdir"),
-        test_suite="plan.yaml",
+        test_suite="one-language-literals.yaml",
         options=Options(
             allow_fallback=False,
             mode=ExecutionMode.PRECOMPILATION,

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -334,6 +334,13 @@ Value = Union[
 class Identifier(str, WithFeatures, WithFunctions):
     """Represents an variable name."""
 
+    is_raw: bool
+
+    def __new__(cls, *args, **kwargs):
+        the_class = str.__new__(cls, *args, **kwargs)
+        the_class.is_raw = False
+        return the_class
+
     def get_used_features(self) -> FeatureSet:
         return FeatureSet(
             set(), set(), {(ComplexExpressionTypes.IDENTIFIERS, frozenset())}
@@ -475,6 +482,7 @@ class Assignment(WithFeatures, WithFunctions):
         return self.expression.get_functions()
 
 
+# If changing this, also update is_statement_strict in the utils.
 Statement = Union[Assignment, Expression]
 
 # Update the forward references, which fixes the schema generation.

--- a/tested/testsuite.py
+++ b/tested/testsuite.py
@@ -37,7 +37,7 @@ from tested.serialisation import (
     Value,
     WithFunctions,
 )
-from tested.utils import flatten
+from tested.utils import flatten, is_statement_strict
 
 
 @unique
@@ -60,6 +60,46 @@ class ExceptionBuiltin(StrEnum):
     """Built-in functions for exceptions."""
 
     EXCEPTION = auto()
+
+
+@unique
+class SupportedLanguage(StrEnum):
+    BASH = auto()
+    C = auto()
+    HASKELL = auto()
+    JAVA = auto()
+    JAVASCRIPT = auto()
+    KOTLIN = auto()
+    PYTHON = auto()
+    RUNHASKELL = auto()
+    CSHARP = auto()
+
+
+LanguageMapping = Dict[SupportedLanguage, str]
+
+
+@define
+class LanguageLiterals(WithFunctions, WithFeatures):
+    literals: LanguageMapping = field()
+    type: Literal["expression", "statement"] = "expression"
+
+    def get_for(self, language: SupportedLanguage):
+        return self.literals[language]
+
+    def is_statement(self) -> bool:
+        return self.type == "statement"
+
+    def get_functions(self) -> Iterable["FunctionCall"]:
+        return []
+
+    def get_used_features(self) -> FeatureSet:
+        return NOTHING
+
+    @literals.validator  # type: ignore
+    def validate_literals(self, _, value):
+        """There should be at least one evaluator."""
+        if len(value.keys()) == 0:
+            raise ValueError("At least one language-specific literal is required.")
 
 
 @define
@@ -149,10 +189,10 @@ class LanguageSpecificOracle:
     instead.
     """
 
-    functions: Dict[str, EvaluationFunction] = field()
+    functions: Dict[SupportedLanguage, EvaluationFunction] = field()
     type: Literal["specific"] = "specific"
 
-    def for_language(self, language: str) -> EvaluationFunction:
+    def for_language(self, language: SupportedLanguage) -> EvaluationFunction:
         return self.functions[language]
 
     @functions.validator  # type: ignore
@@ -384,22 +424,29 @@ class Output(WithFeatures):
             ]
         )
 
-    def get_specific_oracle_languages(self) -> Optional[Set[str]]:
+    def get_specific_languages(self) -> Optional[Set[SupportedLanguage]]:
         """
-        Get the languages supported by this output if language-specific oracles
-        are used. If none are used, None is returned, otherwise a set of languages.
+        Get the languages supported by this output if this output uses any language-specific constructs.
+
+        :return: None if no language-specific stuff is used, a set of supported languages otherwise.
         """
         languages = None
         if isinstance(self.exception, ExceptionOutputChannel):
             if isinstance(self.exception.oracle, LanguageSpecificOracle):
-                languages = set(self.exception.oracle.functions.keys())
+                languages = {
+                    SupportedLanguage(x) for x in self.exception.oracle.functions.keys()
+                }
             elif (
                 self.exception.exception is not None and self.exception.exception.types
             ):
-                languages = set(self.exception.exception.types.keys())
+                languages = {
+                    SupportedLanguage(x) for x in self.exception.exception.types.keys()
+                }
         if isinstance(self.result, ValueOutputChannel):
             if isinstance(self.result.oracle, LanguageSpecificOracle):
-                langs = set(self.result.oracle.functions.keys())
+                langs = {
+                    SupportedLanguage(x) for x in self.result.oracle.functions.keys()
+                }
                 if languages is not None:
                     languages &= langs
                 else:
@@ -461,7 +508,7 @@ class Testcase(WithFeatures, WithFunctions):
     one testcase present.
     """
 
-    input: Statement | MainInput
+    input: Statement | MainInput | LanguageLiterals
     description: Optional[str] = None
     output: Output = field(factory=Output)
     link_files: List[FileUrl] = field(factory=list)
@@ -477,14 +524,19 @@ class Testcase(WithFeatures, WithFunctions):
     def __attrs_post_init__(self):
         # If the expected return value is None and we have a statement, change it
         # to ignore, as they mean the same thing.
-        if (
-            not isinstance(self.input, Expression)
-            and self.output.result == EmptyChannel.NONE
-        ):
+        if is_statement_strict(self.input) and self.output.result == EmptyChannel.NONE:
+            self.output.result = IgnoredChannel.IGNORED
+
+        # We also ignore if it is the main input.
+        if self.is_main_testcase():
+            self.output.result = IgnoredChannel.IGNORED
+
+        # If the language literal is a statement, we also ignore.
+        if isinstance(self.input, LanguageLiterals) and self.input.is_statement():
             self.output.result = IgnoredChannel.IGNORED
 
         # If we have a statement but the output is not None or Ignored, we error.
-        if not isinstance(self.input, Expression) and self.output.result not in (
+        if is_statement_strict(self.input) and self.output.result not in (
             EmptyChannel.NONE,
             IgnoredChannel.IGNORED,
         ):

--- a/tested/utils.py
+++ b/tested/utils.py
@@ -4,10 +4,25 @@ import logging
 import random
 import string
 import sys
-import typing
 from itertools import zip_longest
 from pathlib import Path
-from typing import IO, Any, Callable, Iterable, List, Optional, TypeVar, Union
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    TypeGuard,
+    TypeVar,
+    Union,
+)
+from typing import get_args as typing_get_args
+
+if TYPE_CHECKING:
+    from tested.serialisation import Assignment
+    from tested.testsuite import SupportedLanguage
 
 _logger = logging.getLogger(__name__)
 
@@ -48,7 +63,7 @@ def get_identifier() -> str:
     return letter + "".join(rest)
 
 
-def consume_shebang(submission: Path) -> Optional[str]:
+def consume_shebang(submission: Path) -> Optional["SupportedLanguage"]:
     """
     Find the shebang in the submission, and if it is present, consume it.
 
@@ -56,6 +71,8 @@ def consume_shebang(submission: Path) -> Optional[str]:
 
     :return: The programming language if found.
     """
+    from tested.testsuite import SupportedLanguage
+
     language = None
     try:
         with open(submission, "r+") as file:
@@ -80,7 +97,7 @@ def consume_shebang(submission: Path) -> Optional[str]:
         # Nothing we can do if there is no submission.
         pass
 
-    return language
+    return SupportedLanguage(language) if language else None
 
 
 K = TypeVar("K")
@@ -119,7 +136,7 @@ def get_args(type_: Any) -> tuple[Any, ...]:
     :param type_: The type to resolve.
     :return: The resolved generics or the type itself.
     """
-    if a := typing.get_args(type_):
+    if a := typing_get_args(type_):
         return a
     else:
         return (type_,)
@@ -323,3 +340,16 @@ def sorted_no_duplicates(
             first, last_key = False, key(v)
             no_dup.append(v)
     return no_dup
+
+
+def is_statement_strict(statement: Any) -> TypeGuard["Assignment"]:
+    """
+    Check that the given value is a strict statement: it must be a statement but
+    not an expression.
+
+    :param statement: The potential statement to check.
+    :return: True if it is, False otherwise.
+    """
+    from tested.serialisation import Assignment
+
+    return isinstance(statement, Assignment)

--- a/tests/exercises/echo-function/evaluation/one-language-literals.yaml
+++ b/tests/exercises/echo-function/evaluation/one-language-literals.yaml
@@ -1,0 +1,12 @@
+- tab: "My tab"
+  testcases:
+    - expression:
+        c: "to_string(1+1)"
+        haskell: "Submission.toString (1+1)"
+        runhaskell: "Submission.toString (1+1)"
+        java: "Submission.toString(1+1)"
+        javascript: "submission.toString(1+1)"
+        kotlin: "toString(1+1)"
+        python: "submission.to_string(1+1)"
+        csharp: "Submission.toString(1+1)"
+      return: "2"

--- a/tests/exercises/echo-function/solution/correct.c
+++ b/tests/exercises/echo-function/solution/correct.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <stdio.h>
+
 char* echo(char* content) {
     return content;
 }
@@ -5,4 +8,12 @@ char* echo(char* content) {
 
 void no_echo(char* content) {
     // Do nothing.
+}
+
+
+char* to_string(int number) {
+    int size = snprintf(NULL, 0, "%d", number);
+    char* the_string = malloc((size + 1) * sizeof(char));
+    sprintf(the_string, "%d", number);
+    return the_string;
 }

--- a/tests/exercises/echo-function/solution/correct.cs
+++ b/tests/exercises/echo-function/solution/correct.cs
@@ -11,4 +11,9 @@ class Submission
     {
         // Do nothing.
     }
+    
+    public static string toString(int number)
+    {
+        return number.ToString();
+    }
 }

--- a/tests/exercises/echo-function/solution/correct.hs
+++ b/tests/exercises/echo-function/solution/correct.hs
@@ -2,3 +2,6 @@ echo a = a
 
 noEcho :: String -> ()
 noEcho _ = ()
+
+toString :: Int -> String
+toString = show

--- a/tests/exercises/echo-function/solution/correct.java
+++ b/tests/exercises/echo-function/solution/correct.java
@@ -7,4 +7,8 @@ class Submission {
     public static void noEcho(String value) {
         // Do nothing.
     }
+    
+    public static String toString(int number) {
+        return Integer.toString(number);
+    }
 }

--- a/tests/exercises/echo-function/solution/correct.js
+++ b/tests/exercises/echo-function/solution/correct.js
@@ -6,3 +6,7 @@ function echo(content) {
 function noEcho(content) {
     // Do nothing.
 }
+
+function toString(number) {
+    return number.toString()
+}

--- a/tests/exercises/echo-function/solution/correct.kt
+++ b/tests/exercises/echo-function/solution/correct.kt
@@ -5,3 +5,7 @@ fun echo(content : Any?) : Any? {
 fun noEcho(content : Any?) {
     // Do nothing
 }
+
+fun toString(content: Int): String {
+    return content.toString()
+}

--- a/tests/exercises/echo-function/solution/correct.py
+++ b/tests/exercises/echo-function/solution/correct.py
@@ -4,3 +4,6 @@ def echo(content):
 
 def no_echo(content):
     pass
+
+def to_string(n):
+    return str(n)

--- a/tests/exercises/echo-function/solution/correct.sh
+++ b/tests/exercises/echo-function/solution/correct.sh
@@ -1,7 +1,7 @@
 function my_echo {
     echo "$1"
 }
-alias echo=my_echo
+
 
 function no_echo {
     : # Do nothing here

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -984,3 +984,19 @@ def test_ignored_return_and_got_some(language: str, tmp_path: Path, pytestconfig
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
     assert updates.find_status_enum() == []  # Empty means correct
+
+
+@pytest.mark.parametrize("language", ALL_SPECIFIC_LANGUAGES)
+def test_language_literals_work(language: str, tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "echo-function",
+        language,
+        tmp_path,
+        "one-language-literals.yaml",
+        "correct",
+    )
+
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"]


### PR DESCRIPTION
Fixes #399.

As mentioned in the issue, you do need to be aware if you need to namespace function calls for each language or not. For example:


```yaml
- tab: "My tab"
  testcases:
  - expression:
      c: "to_string(1+1)"
      haskell: "Submission.toString (1+1)"
      runhaskell: "Submission.toString (1+1)"
      java: "Submission.toString(1+1)"
      javascript: "submission.toString(1+1)"
      kotlin: "toString(1+1)"
      python: "submission.to_string(1+1)"
      csharp: "Submission.toString(1+1)"
    return: "2"
```