### PR TITLE
Fix crash in JS

### DIFF
--- a/tested/languages/javascript/templates/values.js
+++ b/tested/languages/javascript/templates/values.js
@@ -39,7 +39,16 @@ function encode(value) {
             type = "null";
         } else if (Array.isArray(value)) {
             type = "list";
-            value = value.map(encode);
+            // Handle holes in arrays...
+            const unholed = [];
+            for (let i = 0; i < value.length; i++) {
+                if (!value.hasOwnProperty(i)) {
+                    unholed.push(`<empty at index ${i}>`)
+                } else {
+                    unholed.push(value[i]);
+                }
+            }
+            value = unholed.map(encode);
         } else if (value instanceof Set) {
             type = "set";
             value = Array.from(value).map(encode);

--- a/tested/oracles/value.py
+++ b/tested/oracles/value.py
@@ -286,7 +286,7 @@ def evaluate(
     if actual is None:
         return OracleResult(
             result=StatusMessage(
-                enum=Status.WRONG, human=get_i18n_string("functions.value.missing")
+                enum=Status.WRONG, human=get_i18n_string("evaluators.value.missing")
             ),
             readable_expected=readable_expected,
             readable_actual=readable_actual,


### PR DESCRIPTION
We didn't handle "holes" in JS arrays.

For example, https://dodona.be/en/submissions/14641782/.