### PR TITLE
Allow alternative test hierarchy names

### DIFF
--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -8,32 +8,32 @@
       "$ref" : "#/definitions/_rootObject"
     },
     {
-      "$ref" : "#/definitions/tab"
+      "$ref" : "#/definitions/unit"
     },
     {
-      "$ref" : "#/definitions/_tabList"
+      "$ref" : "#/definitions/_unitList"
     }
   ],
   "definitions" : {
-    "_tabList" : {
+    "_unitList" : {
       "type" : "array",
       "minItems" : 1,
       "items" : {
-        "$ref" : "#/definitions/tab"
-      }
-    },
-    "_contextList" : {
-      "type" : "array",
-      "minItems" : 1,
-      "items" : {
-        "$ref" : "#/definitions/context"
+        "$ref" : "#/definitions/unit"
       }
     },
     "_testcaseList" : {
       "type" : "array",
       "minItems" : 1,
       "items" : {
-        "$ref" : "#/definitions/testcase"
+        "$ref" : "#/definitions/context"
+      }
+    },
+    "_scriptList" : {
+      "type" : "array",
+      "minItems" : 1,
+      "items" : {
+        "$ref" : "#/definitions/script"
       }
     },
     "_rootObject" : {
@@ -48,7 +48,10 @@
           "description" : "Namespace of the submitted solution, in `snake_case`"
         },
         "tabs" : {
-          "$ref" : "#/definitions/_tabList"
+          "$ref" : "#/definitions/_unitList"
+        },
+        "units" : {
+          "$ref" : "#/definitions/_unitList"
         },
         "language" : {
           "description" : "Indicate that all code is in a specific language.",
@@ -63,43 +66,88 @@
           "default" : "tested"
         }
       },
-      "required" : [
-        "tabs"
-      ]
-    },
-    "tab" : {
-      "type" : "object",
-      "properties" : {
-        "config" : {
-          "$ref" : "#/definitions/globalConfig",
-          "description" : "Configuration applicable to this tab"
-        },
-        "hidden" : {
-          "type" : "boolean",
-          "description" : "Defines if the tab is hidden for the student or not"
-        },
-        "tab" : {
-          "type" : "string",
-          "description" : "The name of this tab."
-        },
-        "contexts" : {
-          "$ref" : "#/definitions/_contextList"
-        },
-        "testcases" : {
-          "$ref" : "#/definitions/_testcaseList"
-        }
-      },
       "oneOf" : [
         {
           "required" : [
-            "contexts",
-            "tab"
+            "tabs"
           ]
         },
         {
           "required" : [
-            "testcases",
+            "units"
+          ]
+        }
+      ]
+    },
+    "unit" : {
+      "type" : "object",
+      "properties" : {
+        "config" : {
+          "$ref" : "#/definitions/globalConfig",
+          "description" : "Configuration applicable to this unit/tab"
+        },
+        "hidden" : {
+          "type" : "boolean",
+          "description" : "Defines if the unit/tab is hidden for the student or not"
+        }
+      },
+      "oneOf" : [
+        {
+          "properties" : {
+            "tab" : {
+              "type" : "string",
+              "description" : "The name of this tab."
+            },
+            "contexts" : {
+              "$ref" : "#/definitions/_testcaseList"
+            },
+            "testcases" : {
+              "$ref" : "#/definitions/_scriptList"
+            }
+          },
+          "required" : [
             "tab"
+          ],
+          "oneOf" : [
+            {
+              "required" : [
+                "contexts"
+              ]
+            },
+            {
+              "required" : [
+                "testcases"
+              ]
+            }
+          ]
+        },
+        {
+          "properties" : {
+            "unit" : {
+              "type" : "string",
+              "description" : "The name of this unit."
+            },
+            "testcases" : {
+              "$ref" : "#/definitions/_testcaseList"
+            },
+            "scripts" : {
+              "$ref" : "#/definitions/_scriptList"
+            }
+          },
+          "required" : [
+            "unit"
+          ],
+          "oneOf" : [
+            {
+              "required" : [
+                "testcases"
+              ]
+            },
+            {
+              "required" : [
+                "scripts"
+              ]
+            }
           ]
         }
       ]
@@ -116,14 +164,26 @@
           "description" : "Description of this context."
         },
         "testcases" : {
-          "$ref" : "#/definitions/_testcaseList"
+          "$ref" : "#/definitions/_scriptList"
+        },
+        "script" : {
+          "$ref" : "#/definitions/_scriptList"
         }
       },
-      "required" : [
-        "testcases"
+      "oneOf" : [
+        {
+          "required" : [
+            "testcases"
+          ]
+        },
+        {
+          "required" : [
+            "script"
+          ]
+        }
       ]
     },
-    "testcase" : {
+    "script" : {
       "type" : "object",
       "description" : "An individual test for a statement or expression",
       "properties" : {

--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -26,7 +26,7 @@
       "type" : "array",
       "minItems" : 1,
       "items" : {
-        "$ref" : "#/definitions/context"
+        "$ref" : "#/definitions/testcase"
       }
     },
     "_scriptList" : {
@@ -89,22 +89,30 @@
         "hidden" : {
           "type" : "boolean",
           "description" : "Defines if the unit/tab is hidden for the student or not"
+        },
+        "unit" : {
+          "type" : "string",
+          "description" : "The name of this unit."
+        },
+        "tab" : {
+          "type" : "string",
+          "description" : "The name of this tab."
+        },
+        "cases" : {
+          "$ref" : "#/definitions/_testcaseList"
+        },
+        "contexts" : {
+          "$ref" : "#/definitions/_testcaseList"
+        },
+        "scripts" : {
+          "$ref" : "#/definitions/_scriptList"
+        },
+        "testcases" : {
+          "$ref" : "#/definitions/_scriptList"
         }
       },
       "oneOf" : [
         {
-          "properties" : {
-            "tab" : {
-              "type" : "string",
-              "description" : "The name of this tab."
-            },
-            "contexts" : {
-              "$ref" : "#/definitions/_testcaseList"
-            },
-            "testcases" : {
-              "$ref" : "#/definitions/_scriptList"
-            }
-          },
           "required" : [
             "tab"
           ],
@@ -122,25 +130,13 @@
           ]
         },
         {
-          "properties" : {
-            "unit" : {
-              "type" : "string",
-              "description" : "The name of this unit."
-            },
-            "testcases" : {
-              "$ref" : "#/definitions/_testcaseList"
-            },
-            "scripts" : {
-              "$ref" : "#/definitions/_scriptList"
-            }
-          },
           "required" : [
             "unit"
           ],
           "oneOf" : [
             {
               "required" : [
-                "testcases"
+                "cases"
               ]
             },
             {
@@ -152,7 +148,7 @@
         }
       ]
     },
-    "context" : {
+    "testcase" : {
       "type" : "object",
       "properties" : {
         "config" : {

--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -454,10 +454,11 @@ def _convert_tab(tab: YamlDict, context: DslContext) -> Tab:
     if "contexts" in tab:
         assert isinstance(tab["contexts"], list)
         contexts = _convert_dsl_list(tab["contexts"], context, _convert_context)
-    elif "testcases" in tab and "unit" in tab:
+    elif "cases" in tab:
+        assert "unit" in tab
         # We have testcases N.S. / contexts O.S.
-        assert isinstance(tab["testcases"], list)
-        contexts = _convert_dsl_list(tab["testcases"], context, _convert_context)
+        assert isinstance(tab["cases"], list)
+        contexts = _convert_dsl_list(tab["cases"], context, _convert_context)
     elif "testcases" in tab:
         # We have scripts N.S. / testcases O.S.
         assert "tab" in tab

--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -432,8 +432,9 @@ def _convert_testcase(testcase: YamlDict, context: DslContext) -> Testcase:
 
 def _convert_context(context: YamlDict, dsl_context: DslContext) -> Context:
     dsl_context = dsl_context.deepen_config(context)
-    assert isinstance(context["testcases"], list)
-    testcases = _convert_dsl_list(context["testcases"], dsl_context, _convert_testcase)
+    raw_testcases = context.get("script", context.get("testcases"))
+    assert isinstance(raw_testcases, list)
+    testcases = _convert_dsl_list(raw_testcases, dsl_context, _convert_testcase)
     return Context(testcases=testcases)
 
 
@@ -446,16 +447,27 @@ def _convert_tab(tab: YamlDict, context: DslContext) -> Tab:
     :return: A full tab.
     """
     context = context.deepen_config(tab)
-    name = tab["tab"]
+    name = tab.get("unit", tab.get("tab"))
     assert isinstance(name, str)
 
     # The tab can have testcases or contexts.
     if "contexts" in tab:
         assert isinstance(tab["contexts"], list)
         contexts = _convert_dsl_list(tab["contexts"], context, _convert_context)
-    else:
+    elif "testcases" in tab and "unit" in tab:
+        # We have testcases N.S. / contexts O.S.
+        assert isinstance(tab["testcases"], list)
+        contexts = _convert_dsl_list(tab["testcases"], context, _convert_context)
+    elif "testcases" in tab:
+        # We have scripts N.S. / testcases O.S.
+        assert "tab" in tab
         assert isinstance(tab["testcases"], list)
         testcases = _convert_dsl_list(tab["testcases"], context, _convert_testcase)
+        contexts = [Context(testcases=[t]) for t in testcases]
+    else:
+        assert "scripts" in tab
+        assert isinstance(tab["scripts"], list)
+        testcases = _convert_dsl_list(tab["scripts"], context, _convert_testcase)
         contexts = [Context(testcases=[t]) for t in testcases]
 
     return Tab(name=name, contexts=contexts)
@@ -495,7 +507,7 @@ def _convert_dsl(dsl_object: YamlObject) -> Suite:
         assert isinstance(dsl_object, dict)
         namespace = dsl_object.get("namespace")
         context = context.deepen_config(dsl_object)
-        tab_list = dsl_object["tabs"]
+        tab_list = dsl_object.get("units", dsl_object.get("tabs"))
         assert isinstance(tab_list, list)
         if (language := dsl_object.get("language", "tested")) != "tested":
             language = SupportedLanguage(language)

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -890,8 +890,8 @@ def test_one_language_literal():
         java: "IllegalArgumentException"
   - arguments: [ "--arg", "fail2" ]
     exit_code: 10
-- tab: "Ctx Error"
-  testcases:
+- unit: "Ctx Error"
+  scripts:
   - arguments: [ "--arg", "error" ]
     exception:
       message: "Error"
@@ -939,7 +939,7 @@ def test_one_language_literal():
         """,
             """
     - unit: "Statement and main"
-      testcases:
+      cases:
       - script:
           - arguments: [ '-a', '5', '7' ]
             stdout:

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -851,3 +851,111 @@ def test_one_language_literal():
     i2 = test1.input
     assert i2.type == "statement"
     assert i2.literals.keys() == {"javascript", "python"}
+
+
+@pytest.mark.parametrize(
+    "old,new",
+    [
+        (
+            """
+- tab: "Ctx Exception"
+  hidden: false
+  testcases:
+  - arguments: [ "--arg", "fail" ]
+    exception:
+      message: "Exception message"
+      types:
+        javascript: "AssertionError"
+        java: "IllegalArgumentException"
+  - arguments: [ "--arg", "fail2" ]
+    exit_code: 10
+- tab: "Ctx Error"
+  testcases:
+  - arguments: [ "--arg", "error" ]
+    exception:
+      message: "Error"
+      types:
+        csharp: "System.DivideByZeroException"
+        python: "ZeroDivisionError"
+    """,
+            """
+- unit: "Ctx Exception"
+  hidden: false
+  scripts:
+  - arguments: [ "--arg", "fail" ]
+    exception:
+      message: "Exception message"
+      types:
+        javascript: "AssertionError"
+        java: "IllegalArgumentException"
+  - arguments: [ "--arg", "fail2" ]
+    exit_code: 10
+- tab: "Ctx Error"
+  testcases:
+  - arguments: [ "--arg", "error" ]
+    exception:
+      message: "Error"
+      types:
+        csharp: "System.DivideByZeroException"
+        python: "ZeroDivisionError"
+    """,
+        ),
+        (
+            """
+        language: "javascript"
+        tabs:
+        - tab: "Feedback"
+          testcases:
+          - expression: "heir(8, 10)"
+            return: [ 10, 4, 15, 11, 7, 5, 3, 2, 16, 12, 1, 6, 13, 9, 14, 8 ]
+          - statement:
+                javascript: "hello()"
+                python: "hello_2()"
+    """,
+            """
+        language: "javascript"
+        units:
+        - unit: "Feedback"
+          scripts:
+          - expression: "heir(8, 10)"
+            return: [ 10, 4, 15, 11, 7, 5, 3, 2, 16, 12, 1, 6, 13, 9, 14, 8 ]
+          - statement:
+                javascript: "hello()"
+                python: "hello_2()"
+    """,
+        ),
+        (
+            """
+    - tab: "Statement and main"
+      contexts:
+      - testcases:
+          - arguments: [ '-a', '5', '7' ]
+            stdout:
+              data: 12
+              config:
+                tryFloatingPoint: true
+          - expression: 'add(5, 7)'
+            return: 12
+        """,
+            """
+    - unit: "Statement and main"
+      testcases:
+      - script:
+          - arguments: [ '-a', '5', '7' ]
+            stdout:
+              data: 12
+              config:
+                tryFloatingPoint: true
+          - expression: 'add(5, 7)'
+            return: 12
+        """,
+        ),
+    ],
+)
+def test_old_and_new_names_work(old, new):
+    old_json = translate_to_test_suite(old)
+    old_suite = parse_test_suite(old_json)
+    new_json = translate_to_test_suite(new)
+    new_suite = parse_test_suite(new_json)
+
+    assert old_suite == new_suite


### PR DESCRIPTION
Fixes #406.

This allows an alternative naming scheme for the test hierarchy in the DSL:

1. Units N.S. / Tab O.S.
2. Testcases N.S. / Contexts O.S.
3. Script N.S. / Testcase O.S. (a testcase N.S. has one "script", which consists of a number of elements)
4. Tests (not actually named)

The old / existing names are still supported, and probably will keep being supported: they might be useful for Dodona users, and internally TESTed still uses the Dodona terminology.