### PR TITLE
Fix linked files and allow propagation

### DIFF
--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -44,6 +44,12 @@
           "$ref" : "#/$defs/globalConfig",
           "description" : "Configuration applicable to the whole test suite."
         },
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/file"
+          }
+        },
         "namespace" : {
           "type" : "string",
           "description" : "Namespace of the submitted solution, in `snake_case`"
@@ -87,6 +93,12 @@
         "config" : {
           "$ref" : "#/$defs/globalConfig",
           "description" : "Configuration applicable to this unit/tab"
+        },
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/file"
+          }
         },
         "hidden" : {
           "type" : "boolean",
@@ -157,6 +169,12 @@
         "config" : {
           "$ref" : "#/$defs/globalConfig",
           "description" : "Configuration settings at context level"
+        },
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/file"
+          }
         },
         "context" : {
           "type" : "string",

--- a/tested/dsl/schema_draft7.json
+++ b/tested/dsl/schema_draft7.json
@@ -33,7 +33,7 @@
       "type" : "array",
       "minItems" : 1,
       "items" : {
-        "$ref" : "#/definitions/script"
+        "$ref" : "#/definitions/test"
       }
     },
     "_rootObject" : {
@@ -42,6 +42,12 @@
         "config" : {
           "$ref" : "#/definitions/globalConfig",
           "description" : "Configuration applicable to the whole test suite."
+        },
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/file"
+          }
         },
         "namespace" : {
           "type" : "string",
@@ -85,6 +91,12 @@
         "config" : {
           "$ref" : "#/definitions/globalConfig",
           "description" : "Configuration applicable to this unit/tab"
+        },
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/file"
+          }
         },
         "hidden" : {
           "type" : "boolean",
@@ -155,6 +167,12 @@
           "$ref" : "#/definitions/globalConfig",
           "description" : "Configuration settings at context level"
         },
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/file"
+          }
+        },
         "context" : {
           "type" : "string",
           "description" : "Description of this context."
@@ -179,7 +197,7 @@
         }
       ]
     },
-    "script" : {
+    "test" : {
       "type" : "object",
       "description" : "An individual test for a statement or expression",
       "properties" : {

--- a/tested/oracles/exception.py
+++ b/tested/oracles/exception.py
@@ -71,18 +71,18 @@ def evaluate(
         _logger.exception(e)
         staff_message = ExtendedMessage(
             description=get_i18n_string(
-                "evaluators.exception.staff",
+                "oracles.exception.staff",
                 actual=actual_str,
                 exception=traceback.format_exc(),
             ),
             format="text",
             permission=Permission.STAFF,
         )
-        student_message = get_i18n_string("evaluators.exception.student")
+        student_message = get_i18n_string("oracles.exception.student")
         return OracleResult(
             result=StatusMessage(
                 enum=Status.INTERNAL_ERROR,
-                human=get_i18n_string("evaluators.exception.status"),
+                human=get_i18n_string("oracles.exception.status"),
             ),
             readable_expected=readable_expected,
             readable_actual="",

--- a/tested/oracles/exitcode.py
+++ b/tested/oracles/exitcode.py
@@ -25,13 +25,13 @@ def evaluate(_config: OracleConfig, channel: OutputChannel, value: str) -> Oracl
             result=StatusMessage(
                 enum=Status.WRONG,
                 human=get_i18n_string(
-                    "evaluators.exitcode.status.invalid", exit_code=value
+                    "oracles.exitcode.status.invalid", exit_code=value
                 ),
             ),
             readable_expected=str(channel.value),
             readable_actual=str(value),
             messages=[
-                get_i18n_string("evaluators.exitcode.status.message", exit_code=value)
+                get_i18n_string("oracles.exitcode.status.message", exit_code=value)
             ],
         )
 
@@ -39,7 +39,7 @@ def evaluate(_config: OracleConfig, channel: OutputChannel, value: str) -> Oracl
 
     if expected_exit_code != exit_code:
         status = StatusMessage(
-            enum=Status.WRONG, human=get_i18n_string("evaluators.exitcode.status.wrong")
+            enum=Status.WRONG, human=get_i18n_string("oracles.exitcode.status.wrong")
         )
     else:
         status = StatusMessage(enum=Status.CORRECT)

--- a/tested/oracles/nothing.py
+++ b/tested/oracles/nothing.py
@@ -25,7 +25,7 @@ def evaluate_nothing_others(
         error = "runtime" if unexpected_status == Status.RUNTIME_ERROR else "unexpected"
         result = StatusMessage(
             enum=unexpected_status,
-            human=get_i18n_string(f"evaluators.nothing.{error}"),
+            human=get_i18n_string(f"oracles.nothing.{error}"),
         )
     else:
         result = StatusMessage(enum=Status.CORRECT)
@@ -66,7 +66,7 @@ def evaluate_no_return(
         error = "runtime" if unexpected_status == Status.RUNTIME_ERROR else "unexpected"
         result = StatusMessage(
             enum=unexpected_status,
-            human=get_i18n_string(f"evaluators.nothing.{error}"),
+            human=get_i18n_string(f"oracles.nothing.{error}"),
         )
         return OracleResult(
             result=result, readable_expected="", readable_actual=actual, messages=[]

--- a/tested/oracles/programmed.py
+++ b/tested/oracles/programmed.py
@@ -18,7 +18,7 @@ from tested.testsuite import CustomCheckOracle, OracleOutputChannel, OutputChann
 
 _logger = logging.getLogger(__name__)
 
-DEFAULT_STUDENT = get_i18n_string("evaluators.programmed.student.default")
+DEFAULT_STUDENT = get_i18n_string("oracles.programmed.student.default")
 
 
 def evaluate(
@@ -95,7 +95,7 @@ def evaluate(
             messages: List[Message] = [
                 ExtendedMessage(description=DEFAULT_STUDENT, format="text"),
                 ExtendedMessage(
-                    description=get_i18n_string("evaluators.programmed.result"),
+                    description=get_i18n_string("oracles.programmed.result"),
                     format="text",
                     permission=Permission.STAFF,
                 ),
@@ -105,7 +105,7 @@ def evaluate(
                     permission=Permission.STAFF,
                 ),
                 ExtendedMessage(
-                    description=get_i18n_string("evaluators.programmed.stdout"),
+                    description=get_i18n_string("oracles.programmed.stdout"),
                     permission=Permission.STAFF,
                 ),
                 ExtendedMessage(
@@ -114,7 +114,7 @@ def evaluate(
                     permission=Permission.STAFF,
                 ),
                 ExtendedMessage(
-                    description=get_i18n_string("evaluators.programmed.stderr"),
+                    description=get_i18n_string("oracles.programmed.stderr"),
                     permission=Permission.STAFF,
                 ),
                 ExtendedMessage(

--- a/tested/oracles/specific.py
+++ b/tested/oracles/specific.py
@@ -32,11 +32,11 @@ def evaluate(
         return OracleResult(
             result=StatusMessage(
                 enum=Status.WRONG,
-                human=get_i18n_string("evaluators.specific.missing.status"),
+                human=get_i18n_string("oracles.specific.missing.status"),
             ),
             readable_actual="",
             readable_expected="",
-            messages=[get_i18n_string("evaluators.specific.missing.message")],
+            messages=[get_i18n_string("oracles.specific.missing.message")],
         )
 
     try:
@@ -45,16 +45,16 @@ def evaluate(
         _logger.exception(e)
         staff_message = ExtendedMessage(
             description=get_i18n_string(
-                "evaluators.specific.staff", actual=actual_str, e=traceback.format_exc()
+                "oracles.specific.staff", actual=actual_str, e=traceback.format_exc()
             ),
             format="text",
             permission=Permission.STAFF,
         )
-        student_message = get_i18n_string("evaluators.specific.student.default")
+        student_message = get_i18n_string("oracles.specific.student.default")
         return OracleResult(
             result=StatusMessage(
                 enum=Status.INTERNAL_ERROR,
-                human=get_i18n_string("evaluators.specific.status"),
+                human=get_i18n_string("oracles.specific.status"),
             ),
             readable_expected="",
             readable_actual="",

--- a/tested/oracles/text.py
+++ b/tested/oracles/text.py
@@ -120,13 +120,11 @@ def evaluate_file(
 
     # There must be nothing as output.
     if actual:
-        message = get_i18n_string(
-            "evaluators.text.file.unexpected.message", actual=actual
-        )
+        message = get_i18n_string("oracles.text.file.unexpected.message", actual=actual)
         return OracleResult(
             result=StatusMessage(
                 enum=Status.WRONG,
-                human=get_i18n_string("evaluators.text.file.unexpected.status"),
+                human=get_i18n_string("oracles.text.file.unexpected.status"),
             ),
             readable_expected="",
             readable_actual=actual,
@@ -150,7 +148,7 @@ def evaluate_file(
         return OracleResult(
             result=StatusMessage(
                 enum=Status.RUNTIME_ERROR,
-                human=get_i18n_string("evaluators.text.file.not-found"),
+                human=get_i18n_string("oracles.text.file.not-found"),
             ),
             readable_expected=expected,
             readable_actual="",

--- a/tested/oracles/value.py
+++ b/tested/oracles/value.py
@@ -286,7 +286,7 @@ def evaluate(
     if actual is None:
         return OracleResult(
             result=StatusMessage(
-                enum=Status.WRONG, human=get_i18n_string("evaluators.value.missing")
+                enum=Status.WRONG, human=get_i18n_string("oracles.value.missing")
             ),
             readable_expected=readable_expected,
             readable_actual=readable_actual,
@@ -303,10 +303,10 @@ def evaluate(
 
     # If the displayed values are the same, add a message about the type.
     if not type_check and readable_expected == readable_actual:
-        type_status = get_i18n_string("evaluators.value.datatype.wrong")
+        type_status = get_i18n_string("oracles.value.datatype.wrong")
         messages.append(
             get_i18n_string(
-                "evaluators.value.datatype.message",
+                "oracles.value.datatype.message",
                 expected=expected.type,
                 actual=actual.type,
             )

--- a/tested/testsuite.py
+++ b/tested/testsuite.py
@@ -571,6 +571,7 @@ class Testcase(WithFeatures, WithFunctions):
 Code = Dict[str, TextData]
 
 
+@ignore_field(get_converter(), "link_files")
 @define
 class Context(WithFeatures, WithFunctions):
     """
@@ -581,7 +582,6 @@ class Context(WithFeatures, WithFunctions):
     before: Code = field(factory=dict)
     after: Code = field(factory=dict)
     description: Optional[str] = None
-    link_files: List[FileUrl] = field(factory=list)
 
     @testcases.validator  # type: ignore
     def check_testcases(self, _, value: List[Testcase]):
@@ -614,6 +614,12 @@ class Context(WithFeatures, WithFunctions):
 
     def has_exit_testcase(self):
         return not self.testcases[-1].output.exit_code == IgnoredChannel.IGNORED
+
+    def get_files(self) -> Set[FileUrl]:
+        all_files = set()
+        for t in self.testcases:
+            all_files = all_files.union(t.link_files)
+        return all_files
 
 
 def _runs_to_tab_converter(runs: Optional[list]):


### PR DESCRIPTION
Fixes #422.

In addition, allow specifying files at a higher level, e.g. the tab or context in the DSL.