### PR TITLE
Support DSL values in oracles

### DIFF
--- a/tested/internationalization/nl.yaml
+++ b/tested/internationalization/nl.yaml
@@ -77,7 +77,7 @@ nl:
         Contacteer de lesgever.
       unsupported: "Evaluation in %{lang} wordt niet ondersteund."
       unknown:
-        compilation: "Ongekende compilatie fout"
+        compilation: "Ongekende compilatiefout"
       produced:
         stderr: "De evaluatiecode produceerde volgende uitvoer op stderr:"
         stdout: "De evaluatiecode produceerde volgende uitvoer op stdout:"
@@ -86,7 +86,7 @@ nl:
   languages:
     config:
       unknown:
-        compilation: "Ongekende compilatie fout"
+        compilation: "Ongekende compilatiefout"
     generator:
       missing:
         input: "Geen invoer gevonden."

--- a/tested/judge/programmed.py
+++ b/tested/judge/programmed.py
@@ -17,13 +17,9 @@ from tested.features import Construct
 from tested.internationalization import get_i18n_string
 from tested.judge.execution import execute_file, filter_files
 from tested.judge.utils import BaseExecutionResult, copy_from_paths_to_path, run_command
-from tested.languages.generation import (
-    custom_oracle_arguments,
-    generate_custom_evaluator,
-    generate_statement,
-)
+from tested.languages.generation import generate_custom_evaluator, generate_statement
 from tested.oracles.common import BooleanEvalResult
-from tested.serialisation import Value
+from tested.serialisation import FunctionCall, FunctionType, Value
 from tested.testsuite import CustomCheckOracle
 from tested.utils import get_identifier
 
@@ -214,17 +210,15 @@ def _evaluate_python(
     exec(evaluator_code, global_env)
 
     # Call the oracle.
-    literal_expected = generate_statement(eval_bundle, expected)
-    literal_actual = generate_statement(eval_bundle, actual)
-    arguments = custom_oracle_arguments(oracle)
-    literal_arguments = generate_statement(eval_bundle, arguments)
+    check_function_call = FunctionCall(
+        type=FunctionType.FUNCTION,
+        name=oracle.function.name,
+        arguments=[expected, actual, *oracle.arguments],
+    )
+    literal_function_call = generate_statement(eval_bundle, check_function_call)
 
     with _catch_output() as (stdout_, stderr_):
-        exec(
-            f"__tested_test__result = {oracle.function.name}("
-            f"{literal_expected}, {literal_actual}, {literal_arguments})",
-            global_env,
-        )
+        exec(f"__tested_test__result = {literal_function_call}", global_env)
 
     stdout_ = stdout_.getvalue()
     stderr_ = stderr_.getvalue()

--- a/tested/judge/programmed.py
+++ b/tested/judge/programmed.py
@@ -22,7 +22,8 @@ from tested.languages.generation import (
     generate_custom_evaluator,
     generate_statement,
 )
-from tested.serialisation import BooleanEvalResult, EvalResult, Value
+from tested.oracles.common import BooleanEvalResult
+from tested.serialisation import Value
 from tested.testsuite import CustomCheckOracle
 from tested.utils import get_identifier
 
@@ -34,7 +35,7 @@ def evaluate_programmed(
     evaluator: CustomCheckOracle,
     expected: Value,
     actual: Value,
-) -> BaseExecutionResult | EvalResult:
+) -> BaseExecutionResult | BooleanEvalResult:
     """
     Run the custom evaluation. Concerning structure and execution, the custom
     oracle is very similar to the execution of the whole evaluation. It a
@@ -181,7 +182,7 @@ def _evaluate_python(
     oracle: CustomCheckOracle,
     expected: Value,
     actual: Value,
-) -> EvalResult:
+) -> BooleanEvalResult:
     """
     Run an evaluation in Python. While the templates are still used to generate
     code, they are not executed in a separate process, but inside python itself.
@@ -267,13 +268,12 @@ def _evaluate_python(
                 permission=Permission.STAFF,
             )
         )
-        return EvalResult(
+        return BooleanEvalResult(
             result=Status.INTERNAL_ERROR,
             readable_expected=None,
             readable_actual=None,
             messages=messages,
         )
 
-    assert isinstance(result_, BooleanEvalResult)
     result_.messages.extend(messages)
-    return result_.as_eval_result()
+    return result_

--- a/tested/languages/bash/generators.py
+++ b/tested/languages/bash/generators.py
@@ -238,7 +238,7 @@ function json_escape {{
 }}
 
 function send_value {{
-    echo "{{\\"type\\": \\"text\\", \\"data\\": $(json_escape "$1")}}"
+    echo "{{\\"type\\": \\"text\\", \\"data\\": $(json_escape "$1")}}␞"
 }}
 """
     for value in values:

--- a/tested/languages/c/generators.py
+++ b/tested/languages/c/generators.py
@@ -322,6 +322,6 @@ int main() {
 """
     for value in values:
         result += " " * 4 + f"write_value(stdout, {convert_value(value)});\n"
-        result += " " * 4 + 'printf("\\n");\n'
+        result += " " * 4 + 'printf("␞");\n'
     result += "}\n"
     return result

--- a/tested/languages/c/templates/evaluation_result.h
+++ b/tested/languages/c/templates/evaluation_result.h
@@ -15,6 +15,8 @@ typedef struct EvaluationResult {
     char* readableActual;
     size_t nrOfMessages;
     Message** messages;
+    char* dslExpected;
+    char* dslActual;
 } EvaluationResult;
 
 

--- a/tested/languages/csharp/generators.py
+++ b/tested/languages/csharp/generators.py
@@ -478,7 +478,7 @@ def convert_encoder(values: list[Value]) -> str:
 
     for value in values:
         result += " " * 6 + f"Values.WriteValue(stdout, {convert_value(value)});"
-        result += " " * 6 + 'stdout.Write("\\n");\n'
+        result += " " * 6 + 'stdout.Write("␞");\n'
 
     result += "}\n}\n}\n"
     return result

--- a/tested/languages/csharp/templates/EvaluationResult.cs
+++ b/tested/languages/csharp/templates/EvaluationResult.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 namespace Tested {
   public record Message(string Description, string Format = "text", string? Permission = null);
-  public record EvaluationResult(bool Result, string? ReadableExpected = null, string? ReadableActual = null, List<Message>? Messages = null)
+  public record EvaluationResult(bool Result, string? ReadableExpected = null, string? ReadableActual = null, List<Message>? Messages = null, string? DslExpected = null, string? DslActual = null)
   {
     public List<Message> Messages { get; init; } = Messages ?? new List<Message>();
   }

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -17,7 +17,7 @@ from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
 
 from tested.configs import Bundle
-from tested.datatypes import AllTypes, BasicObjectTypes, BasicSequenceTypes
+from tested.datatypes import AllTypes, BasicObjectTypes
 from tested.dodona import ExtendedMessage
 from tested.internationalization import get_i18n_string
 from tested.judge.planning import PlannedExecutionUnit
@@ -40,7 +40,6 @@ from tested.serialisation import (
     Expression,
     FunctionType,
     Identifier,
-    SequenceType,
     Statement,
     Value,
     VariableType,
@@ -294,12 +293,6 @@ def generate_selector(
     return selector_filename
 
 
-def custom_oracle_arguments(oracle: CustomCheckOracle) -> Value:
-    return SequenceType(
-        type=BasicSequenceTypes.SEQUENCE, data=oracle.arguments  # pyright: ignore
-    )
-
-
 def generate_custom_evaluator(
     bundle: Bundle,
     destination: Path,
@@ -321,13 +314,12 @@ def generate_custom_evaluator(
     evaluator_name = conventionalize_namespace(
         bundle.language, evaluator.function.file.stem
     )
-    arguments = custom_oracle_arguments(evaluator)
 
     function = PreparedFunctionCall(
         type=FunctionType.FUNCTION,
         namespace=Identifier(evaluator_name),
         name=evaluator.function.name,
-        arguments=[expected_value, actual_value, arguments],
+        arguments=[expected_value, actual_value, *evaluator.arguments],
         has_root_namespace=False,
     )
 

--- a/tested/languages/haskell/generators.py
+++ b/tested/languages/haskell/generators.py
@@ -350,5 +350,5 @@ main = do
 
     for value in values:
         result += indent + f"sendValueH stdout ({convert_value(value)})\n"
-        result += indent + 'putStr "\\n"\n'
+        result += indent + 'putStr "␞"\n'
     return result

--- a/tested/languages/haskell/templates/EvaluationUtils.hs
+++ b/tested/languages/haskell/templates/EvaluationUtils.hs
@@ -11,7 +11,9 @@ data EvaluationResult = EvaluationResult {
     result :: Bool,
     readableExpected :: Maybe (String),
     readableActual :: Maybe (String),
-    messages :: [Message]
+    messages :: [Message],
+    dslExpected :: Maybe (String),
+    dslActual :: Maybe (String)
 } deriving Show
 
 message description = Message {
@@ -24,5 +26,7 @@ evaluationResult = EvaluationResult {
     result = False,
     readableExpected = Nothing,
     readableActual = Nothing,
+    dslExpected = Nothing,
+    dslActual = Nothing,
     messages = []
 }

--- a/tested/languages/java/generators.py
+++ b/tested/languages/java/generators.py
@@ -450,7 +450,7 @@ public class Encode {
 
     for value in values:
         result += " " * 8 + f"Values.send(writer, {convert_value(value)});\n"
-        result += " " * 8 + 'writer.write("\\n");\n'
+        result += " " * 8 + 'writer.write("␞");\n'
 
     result += " " * 8 + "writer.close();\n"
     result += " " * 4 + "}\n"

--- a/tested/languages/java/templates/EvaluationResult.java
+++ b/tested/languages/java/templates/EvaluationResult.java
@@ -6,12 +6,16 @@ public class EvaluationResult {
     public final boolean result;
     public final String readableExpected;
     public final String readableActual;
+    public final String dslExpected;
+    public final String dslActual;
     public final List<Message> messages;
 
-    private EvaluationResult(boolean result, String readableExpected, String readableActual, List<Message> messages) {
+    private EvaluationResult(boolean result, String readableExpected, String readableActual, String dslExpected, String dslActual, List<Message> messages) {
         this.result = result;
         this.readableExpected = readableExpected;
         this.readableActual = readableActual;
+        this.dslExpected = dslExpected;
+        this.dslActual = dslActual;
         this.messages = messages;
     }
 
@@ -44,6 +48,8 @@ public class EvaluationResult {
         private final boolean result;
         private String readableExpected = null;
         private String readableActual = null;
+        private String dslExpected = null;
+        private String dslActual = null;
         private final List<Message> messages = new ArrayList<>();
 
         private Builder(boolean result) {
@@ -59,6 +65,16 @@ public class EvaluationResult {
             this.readableActual = readableActual;
             return this;
         }
+        
+        public Builder withDslExpected(String dslExpected) {
+            this.dslExpected = dslExpected;
+            return this;
+        }
+
+        public Builder withDslActual(String dslActual) {
+            this.dslActual = dslActual;
+            return this;
+        }
 
         public Builder withMessages(List<Message> messages) {
             this.messages.addAll(messages);
@@ -71,7 +87,7 @@ public class EvaluationResult {
         }
 
         public EvaluationResult build() {
-            return new EvaluationResult(result, readableExpected, readableActual, messages);
+            return new EvaluationResult(result, readableExpected, readableActual, dslExpected, dslActual, messages);
         }
     }
 }

--- a/tested/languages/javascript/config.py
+++ b/tested/languages/javascript/config.py
@@ -165,11 +165,6 @@ class JavaScript(Language):
         compilation_submission_location = str(submission_location.resolve())
         execution_location_regex = f"{self.config.dodona.workdir}/{EXECUTION_PREFIX}[_0-9]+/{EXECUTION_PREFIX}[_0-9]+.js"
         submission_namespace = f"{submission_name(self)}."
-        location_pattern = r"(\d+):(\d+)"
-
-        def update_line_number(match: re.Match) -> str:
-            assert self.config
-            return f"{int(match.group(1)) + self.config.dodona.source_offset}:{match.group(2)}"
 
         resulting_lines = ""
         for line in traceback.splitlines(keepends=True):
@@ -182,9 +177,6 @@ class JavaScript(Language):
             line = line.replace(compilation_submission_location, "<code>")
             # Remove any references of the form "submission.SOMETHING"
             line = line.replace(submission_namespace, "")
-
-            # Adjust line numbers
-            line = re.sub(location_pattern, update_line_number, line)
 
             resulting_lines += line
 

--- a/tested/languages/javascript/generators.py
+++ b/tested/languages/javascript/generators.py
@@ -275,6 +275,6 @@ def convert_encoder(values: list[Value]) -> str:
 
     for value in values:
         result += f"values.sendValue(process.stdout.fd, {convert_value(value)});\n"
-        result += 'fs.writeSync(process.stdout.fd, "\\n");\n'
+        result += 'fs.writeSync(process.stdout.fd, "␞");\n'
 
     return result

--- a/tested/languages/kotlin/generators.py
+++ b/tested/languages/kotlin/generators.py
@@ -422,7 +422,7 @@ def convert_encoder(values: list[Value]) -> str:
 
     for value in values:
         result += " " * 4 + f"valuesSend(writer, {convert_value(value)})\n"
-        result += " " * 4 + 'writer.write("\\n")\n'
+        result += " " * 4 + 'writer.write("␞")\n'
 
     result += " " * 4 + "writer.close()\n"
     result += "}\n"

--- a/tested/languages/kotlin/templates/EvaluationResult.kt
+++ b/tested/languages/kotlin/templates/EvaluationResult.kt
@@ -2,6 +2,8 @@ class EvaluationResult private constructor(
         val result: Boolean,
         val readableExpected: String?,
         val readableActual: String?,
+        val dslExpected: String?,
+        val dslActual: String?,
         val messages: List<Message>
 ) {
     class Message(val description: String,
@@ -11,7 +13,9 @@ class EvaluationResult private constructor(
     class Builder(
             private val result: Boolean,
             private var readableActual: String? = null,
-            private var readableExpected: String? = null
+            private var readableExpected: String? = null,
+            private var dslActual: String? = null,
+            private var dslExpected: String? = null
     ) {
         private val messages: MutableList<Message> = ArrayList()
 
@@ -22,6 +26,16 @@ class EvaluationResult private constructor(
 
         fun withReadableExpected(readableExpected: String?): Builder {
             this.readableExpected = readableExpected
+            return this
+        }
+
+        fun withDslActual(dslActual: String?): Builder {
+            this.dslActual = dslActual
+            return this
+        }
+
+        fun withDslExpected(dslExpected: String?): Builder {
+            this.dslExpected = dslExpected
             return this
         }
 
@@ -37,7 +51,7 @@ class EvaluationResult private constructor(
 
         fun build(): EvaluationResult {
             return EvaluationResult(result, readableExpected,
-                    readableActual, messages)
+                    readableActual, dslExpected, dslActual, messages)
         }
     }
 }

--- a/tested/languages/python/generators.py
+++ b/tested/languages/python/generators.py
@@ -264,5 +264,5 @@ from decimal import Decimal
 
     for value in values:
         result += f"values.send_value(sys.stdout, {convert_value(value)})\n"
-        result += "print()\n"
+        result += "print('␞')\n"
     return result

--- a/tested/languages/python/templates/evaluation_utils.py
+++ b/tested/languages/python/templates/evaluation_utils.py
@@ -15,3 +15,5 @@ class EvaluationResult:
     readable_expected: Optional[str] = None
     readable_actual: Optional[str] = None
     messages: List[Message] = field(default_factory=list)
+    dsl_expected: Optional[str] = None
+    dsl_actual: Optional[str] = None

--- a/tested/oracles/common.py
+++ b/tested/oracles/common.py
@@ -79,7 +79,11 @@ class BooleanEvalResult:
     dsl_actual: str | None = None
 
     def to_oracle_result(
-        self, bundle: Bundle, channel: NormalOutputChannel
+        self,
+        bundle: Bundle,
+        channel: NormalOutputChannel,
+        fallback_actual: str,
+        fallback_expected: str,
     ) -> OracleResult:
         if isinstance(self.result, Status):
             status = self.result
@@ -92,14 +96,14 @@ class BooleanEvalResult:
             parsed_statement = parse_string(self.dsl_expected, True)
             readable_expected = generate_statement(bundle, parsed_statement)
         else:
-            readable_expected = ""
+            readable_expected = fallback_expected
         if self.readable_actual:
             readable_actual = self.readable_actual
         elif self.dsl_actual:
             parsed_statement = parse_string(self.dsl_actual, True)
             readable_actual = generate_statement(bundle, parsed_statement)
         else:
-            readable_actual = ""
+            readable_actual = fallback_actual
         messages = self.messages
 
         if isinstance(channel, ExceptionOutputChannel):

--- a/tested/oracles/common.py
+++ b/tested/oracles/common.py
@@ -31,8 +31,10 @@ from attrs import define, field
 
 from tested.configs import Bundle
 from tested.dodona import Message, Status, StatusMessage
+from tested.dsl import parse_string
+from tested.languages.generation import generate_statement
 from tested.languages.utils import convert_stacktrace_to_clickable_feedback
-from tested.serialisation import EvalResult
+from tested.parsing import fallback_field, get_converter
 from tested.testsuite import ExceptionOutputChannel, NormalOutputChannel, OutputChannel
 
 
@@ -49,6 +51,74 @@ class OracleResult:
     is_multiline_string: bool = (
         False  # Indicates if the evaluation result is a multiline string.
     )
+
+
+@fallback_field(
+    get_converter(),
+    {
+        "readableExpected": "readable_expected",
+        "readableActual": "readable_actual",
+        "dslExpected": "dsl_expected",
+        "dslActual": "dsl_actual",
+    },
+)
+@define
+class BooleanEvalResult:
+    """
+    Allows a boolean result.
+
+    Note: this class is used directly in the Python oracle, so keep it backwards
+    compatible (also positional arguments) or make a new class for the oracle.
+    """
+
+    result: bool | Status
+    readable_expected: str | None = None
+    readable_actual: str | None = None
+    messages: list[Message] = field(factory=list)
+    dsl_expected: str | None = None
+    dsl_actual: str | None = None
+
+    def to_oracle_result(
+        self, bundle: Bundle, channel: NormalOutputChannel
+    ) -> OracleResult:
+        if isinstance(self.result, Status):
+            status = self.result
+        else:
+            status = Status.CORRECT if self.result else Status.WRONG
+
+        if self.readable_expected:
+            readable_expected = self.readable_expected
+        elif self.dsl_expected:
+            parsed_statement = parse_string(self.dsl_expected, True)
+            readable_expected = generate_statement(bundle, parsed_statement)
+        else:
+            readable_expected = ""
+        if self.readable_actual:
+            readable_actual = self.readable_actual
+        elif self.dsl_actual:
+            parsed_statement = parse_string(self.dsl_actual, True)
+            readable_actual = generate_statement(bundle, parsed_statement)
+        else:
+            readable_actual = ""
+        messages = self.messages
+
+        if isinstance(channel, ExceptionOutputChannel):
+            readable_expected = bundle.language.cleanup_stacktrace(readable_expected)
+            message = convert_stacktrace_to_clickable_feedback(
+                bundle.language, readable_actual
+            )
+            if message:
+                messages.append(message)
+
+            if status == Status.CORRECT:
+                readable_actual = ""
+
+        return OracleResult(
+            result=StatusMessage(enum=status),
+            readable_expected=readable_expected,
+            readable_actual=readable_actual,
+            messages=messages,
+        )
 
 
 @define
@@ -86,24 +156,3 @@ def try_outputs(
         if possible is not None:
             return possible, msg
     return actual, None
-
-
-def cleanup_specific_programmed(
-    config: OracleConfig, channel: NormalOutputChannel, actual: EvalResult
-) -> EvalResult:
-    if isinstance(channel, ExceptionOutputChannel):
-        lang_config = config.bundle.language
-        actual.readable_expected = lang_config.cleanup_stacktrace(
-            actual.readable_expected or ""
-        )
-        message = convert_stacktrace_to_clickable_feedback(
-            lang_config, actual.readable_actual
-        )
-
-        if message:
-            actual.messages.append(message)
-
-        if actual.result == Status.CORRECT:
-            actual.readable_actual = ""
-
-    return actual

--- a/tested/oracles/exception.py
+++ b/tested/oracles/exception.py
@@ -24,7 +24,6 @@ def try_as_readable_exception(
     # noinspection PyBroadException
     try:
         actual = get_converter().loads(value, ExceptionValue)
-        actual.stacktrace = config.bundle.language.cleanup_stacktrace(actual.stacktrace)
     except Exception:
         return None, None
     else:

--- a/tested/oracles/exception.py
+++ b/tested/oracles/exception.py
@@ -12,9 +12,8 @@ from tested.testsuite import ExceptionOutputChannel, OutputChannel
 _logger = logging.getLogger(__name__)
 
 
-def try_as_exception(config: OracleConfig, value: str) -> ExceptionValue:
+def try_as_exception(value: str) -> ExceptionValue:
     actual = get_converter().loads(value, ExceptionValue)
-    actual.stacktrace = config.bundle.language.cleanup_stacktrace(actual.stacktrace)
     return actual
 
 
@@ -62,7 +61,7 @@ def evaluate(
         )
 
     try:
-        actual = try_as_exception(config, actual_str)
+        actual = try_as_exception(actual_str)
     except Exception as e:
         _logger.exception(e)
         staff_message = ExtendedMessage(

--- a/tested/oracles/nothing.py
+++ b/tested/oracles/nothing.py
@@ -40,7 +40,11 @@ def evaluate_no_return(
     expected = NothingType()
 
     try:
-        value = parse_value(actual)
+        if actual == "":
+            # If there was an exception, we still get the empty string.
+            value = NothingType()
+        else:
+            value = parse_value(actual)
     except Exception as e:
         raw_message = f"Could not parse {actual}, which caused {e} for get_values."
         message = ExtendedMessage(

--- a/tested/oracles/programmed.py
+++ b/tested/oracles/programmed.py
@@ -126,4 +126,6 @@ def evaluate(
         assert isinstance(result, BooleanEvalResult)
         evaluation_result = result
 
-    return evaluation_result.to_oracle_result(config.bundle, channel)
+    return evaluation_result.to_oracle_result(
+        config.bundle, channel, readable_actual, readable_expected
+    )

--- a/tested/oracles/specific.py
+++ b/tested/oracles/specific.py
@@ -56,4 +56,4 @@ def evaluate(
             messages=[staff_message, student_message],
         )
 
-    return actual.to_oracle_result(config.bundle, channel)
+    return actual.to_oracle_result(config.bundle, channel, "", "")

--- a/tested/oracles/specific.py
+++ b/tested/oracles/specific.py
@@ -6,13 +6,8 @@ import traceback
 
 from tested.dodona import ExtendedMessage, Permission, Status, StatusMessage
 from tested.internationalization import get_i18n_string
-from tested.oracles.common import (
-    OracleConfig,
-    OracleResult,
-    cleanup_specific_programmed,
-)
+from tested.oracles.common import BooleanEvalResult, OracleConfig, OracleResult
 from tested.parsing import get_converter
-from tested.serialisation import BooleanEvalResult
 from tested.testsuite import LanguageSpecificOracle, OracleOutputChannel, OutputChannel
 
 _logger = logging.getLogger(__name__)
@@ -40,7 +35,7 @@ def evaluate(
         )
 
     try:
-        actual = get_converter().loads(actual_str, BooleanEvalResult).as_eval_result()
+        actual = get_converter().loads(actual_str, BooleanEvalResult)
     except Exception as e:
         _logger.exception(e)
         staff_message = ExtendedMessage(
@@ -61,11 +56,4 @@ def evaluate(
             messages=[staff_message, student_message],
         )
 
-    actual = cleanup_specific_programmed(config, channel, actual)
-
-    return OracleResult(
-        result=StatusMessage(enum=actual.result),
-        readable_expected=actual.readable_expected or "",
-        readable_actual=actual.readable_actual or "",
-        messages=actual.messages,
-    )
+    return actual.to_oracle_result(config.bundle, channel)

--- a/tested/serialisation.py
+++ b/tested/serialisation.py
@@ -50,9 +50,8 @@ from tested.datatypes import (
     StringTypes,
     resolve_to_basic,
 )
-from tested.dodona import Message, Status
 from tested.features import Construct, FeatureSet, WithFeatures, combine_features
-from tested.parsing import fallback_field, get_converter, parse_json_value
+from tested.parsing import parse_json_value
 from tested.utils import flatten, sorted_no_duplicates
 
 logger = logging.getLogger(__name__)
@@ -686,46 +685,6 @@ def to_python_comparable(value: Value | None) -> Any:
         return value.data
 
     raise AssertionError(f"Unknown value type: {value}")
-
-
-@fallback_field(
-    get_converter(),
-    {"readableExpected": "readable_expected", "readableActual": "readable_actual"},
-)
-@define
-class EvalResult:
-    result: Status
-    readable_expected: str | None = None
-    readable_actual: str | None = None
-    messages: list[Message] = field(factory=list)
-
-
-@fallback_field(
-    get_converter(),
-    {"readableExpected": "readable_expected", "readableActual": "readable_actual"},
-)
-@define
-class BooleanEvalResult:
-    """
-    Allows a boolean result.
-    """
-
-    result: bool | Status
-    readable_expected: str | None = None
-    readable_actual: str | None = None
-    messages: list[Message] = field(factory=list)
-
-    def as_eval_result(self) -> EvalResult:
-        if isinstance(self.result, Status):
-            status = self.result
-        else:
-            status = Status.CORRECT if self.result else Status.WRONG
-        return EvalResult(
-            result=status,
-            readable_expected=self.readable_expected,
-            readable_actual=self.readable_actual,
-            messages=self.messages,
-        )
 
 
 @define

--- a/tested/testsuite.py
+++ b/tested/testsuite.py
@@ -412,8 +412,7 @@ class Output(WithFeatures):
     file: FileOutput = IgnoredChannel.IGNORED
     exception: ExceptionOutput = EmptyChannel.NONE
     result: ValueOutput = EmptyChannel.NONE
-    # This default value is adjusted later, based on the position of the output.
-    exit_code: ExitOutput = EmptyChannel.NONE
+    exit_code: ExitOutput = IgnoredChannel.IGNORED
 
     def get_used_features(self) -> FeatureSet:
         return combine_features(
@@ -584,14 +583,6 @@ class Context(WithFeatures, WithFunctions):
     before: Code = field(factory=dict)
     after: Code = field(factory=dict)
     description: str | None = None
-
-    def __attrs_post_init__(self):
-        # Fix the default value of the exit code outputs.
-        for non_last_testcase in self.testcases[:-1]:
-            if non_last_testcase.output.exit_code == EmptyChannel.NONE:
-                non_last_testcase.output.exit_code = IgnoredChannel.IGNORED
-        if (last_testcase := self.testcases[-1]).output.exit_code == EmptyChannel.NONE:
-            last_testcase.output.exit_code = ExitCodeOutputChannel()
 
     @testcases.validator  # type: ignore
     def check_testcases(self, _, value: list[Testcase]):

--- a/tests/exercises/echo-function/evaluation/Evaluator.cs
+++ b/tests/exercises/echo-function/evaluation/Evaluator.cs
@@ -12,4 +12,9 @@ public class Evaluator {
         var messages = new List<Message>() {new Tested.Message("Hallo")};
         return new EvaluationResult(expected == actual, expected.ToString(), actual != null ? actual.ToString() : "", messages);
     }
+    
+    public static EvaluationResult EvaluateValueDsl(Object expected, Object actual, IList arguments) {
+            var messages = new List<Message>() {new Tested.Message("Hallo")};
+            return new EvaluationResult(expected == actual, null, null, messages, "{5, 5}", "{4, 4}");
+        }
 }

--- a/tests/exercises/echo-function/evaluation/Evaluator.cs
+++ b/tests/exercises/echo-function/evaluation/Evaluator.cs
@@ -8,12 +8,12 @@ public class Evaluator {
         return new EvaluationResult(correct, "correct", actual != null ? actual.ToString() : "", messages);
     }
 
-    public static EvaluationResult EvaluateValue(Object expected, Object actual, IList arguments) {
+    public static EvaluationResult EvaluateValue(Object expected, Object actual) {
         var messages = new List<Message>() {new Tested.Message("Hallo")};
         return new EvaluationResult(expected == actual, expected.ToString(), actual != null ? actual.ToString() : "", messages);
     }
     
-    public static EvaluationResult EvaluateValueDsl(Object expected, Object actual, IList arguments) {
+    public static EvaluationResult EvaluateValueDsl(Object expected, Object actual) {
             var messages = new List<Message>() {new Tested.Message("Hallo")};
             return new EvaluationResult(expected == actual, null, null, messages, "{5, 5}", "{4, 4}");
         }

--- a/tests/exercises/echo-function/evaluation/Evaluator.hs
+++ b/tests/exercises/echo-function/evaluation/Evaluator.hs
@@ -15,8 +15,8 @@ evaluate value  =
     }
 
 
-evaluate_value :: String -> String -> [String] -> EvaluationResult
-evaluate_value expected actual arguments =
+evaluate_value :: String -> String -> EvaluationResult
+evaluate_value expected actual =
     let correct = if actual == expected then True else False
     in evaluationResult {
         result = correct,

--- a/tests/exercises/echo-function/evaluation/Evaluator.java
+++ b/tests/exercises/echo-function/evaluation/Evaluator.java
@@ -18,4 +18,12 @@ public class Evaluator {
                 .withMessage(new EvaluationResult.Message("Hallo"))
                 .build();
     }
+
+    public static EvaluationResult evaluateValueDsl(Object expected, Object actual, List<?> arguments) {
+        return EvaluationResult.builder(expected.equals(actual))
+                .withDslExpected("{5, 5}")
+                .withDslActual("{4, 4}")
+                .withMessage(new EvaluationResult.Message("Hallo"))
+                .build();
+    }
 }

--- a/tests/exercises/echo-function/evaluation/Evaluator.java
+++ b/tests/exercises/echo-function/evaluation/Evaluator.java
@@ -11,7 +11,7 @@ public class Evaluator {
                 .build();
     }
 
-    public static EvaluationResult evaluateValue(Object expected, Object actual, List<?> arguments) {
+    public static EvaluationResult evaluateValue(Object expected, Object actual) {
         return EvaluationResult.builder(expected.equals(actual))
                 .withReadableExpected(expected.toString())
                 .withReadableActual(actual != null ? actual.toString() : "")
@@ -19,7 +19,7 @@ public class Evaluator {
                 .build();
     }
 
-    public static EvaluationResult evaluateValueDsl(Object expected, Object actual, List<?> arguments) {
+    public static EvaluationResult evaluateValueDsl(Object expected, Object actual) {
         return EvaluationResult.builder(expected.equals(actual))
                 .withDslExpected("{5, 5}")
                 .withDslActual("{4, 4}")

--- a/tests/exercises/echo-function/evaluation/Evaluator.kt
+++ b/tests/exercises/echo-function/evaluation/Evaluator.kt
@@ -17,5 +17,14 @@ class Evaluator {
                     .withMessage(EvaluationResult.Message("Hallo"))
                     .build()
         }
+
+        @JvmStatic
+        fun evaluateValueDsl(expected: Any, actual: Any?, arguments: List<Any?>?): EvaluationResult {
+            return EvaluationResult.Builder(result = expected == actual,
+                    dslExpected = "{5, 5}",
+                    dslActual = "{4, 4}")
+                    .withMessage(EvaluationResult.Message("Hallo"))
+                    .build()
+        }
     }
 }

--- a/tests/exercises/echo-function/evaluation/Evaluator.kt
+++ b/tests/exercises/echo-function/evaluation/Evaluator.kt
@@ -10,7 +10,7 @@ class Evaluator {
         }
 
         @JvmStatic
-        fun evaluateValue(expected: Any, actual: Any?, arguments: List<Any?>?): EvaluationResult {
+        fun evaluateValue(expected: Any, actual: Any?): EvaluationResult {
             return EvaluationResult.Builder(result = expected == actual,
                     readableExpected = expected.toString(),
                     readableActual = actual?.toString() ?: "")
@@ -19,7 +19,7 @@ class Evaluator {
         }
 
         @JvmStatic
-        fun evaluateValueDsl(expected: Any, actual: Any?, arguments: List<Any?>?): EvaluationResult {
+        fun evaluateValueDsl(expected: Any, actual: Any?): EvaluationResult {
             return EvaluationResult.Builder(result = expected == actual,
                     dslExpected = "{5, 5}",
                     dslActual = "{4, 4}")

--- a/tests/exercises/echo-function/evaluation/evaluator.js
+++ b/tests/exercises/echo-function/evaluation/evaluator.js
@@ -8,7 +8,7 @@ function evaluate(actual) {
     }
 }
 
-function evaluateValue(expected, actual, args) {
+function evaluateValue(expected, actual) {
     return {
         "result": expected === actual,
         "readable_expected": expected,
@@ -17,7 +17,7 @@ function evaluateValue(expected, actual, args) {
     }
 }
 
-function evaluateValueDsl(expected, actual, args) {
+function evaluateValueDsl(expected, actual) {
     return {
         "result": expected === actual,
         "dsl_expected": "{5, 5}",

--- a/tests/exercises/echo-function/evaluation/evaluator.js
+++ b/tests/exercises/echo-function/evaluation/evaluator.js
@@ -11,11 +11,21 @@ function evaluate(actual) {
 function evaluateValue(expected, actual, args) {
     return {
         "result": expected === actual,
-        "expected": expected,
-        "actual": actual,
+        "readable_expected": expected,
+        "readable_actual": actual,
+        "messages": [{"description": "Hallo", "format": "text"}]
+    }
+}
+
+function evaluateValueDsl(expected, actual, args) {
+    return {
+        "result": expected === actual,
+        "dsl_expected": "{5, 5}",
+        "dsl_actual": "{4, 4}",
         "messages": [{"description": "Hallo", "format": "text"}]
     }
 }
 
 exports.evaluate = evaluate;
 exports.evaluateValue = evaluateValue;
+exports.evaluateValueDsl = evaluateValueDsl;

--- a/tests/exercises/echo-function/evaluation/evaluator.py
+++ b/tests/exercises/echo-function/evaluation/evaluator.py
@@ -8,3 +8,12 @@ def evaluate(actual):
 
 def evaluate_value(expected, actual, args):
     return EvaluationResult(expected == actual, expected, actual, [Message("Hallo")])
+
+
+def evaluate_value_dsl(expected, actual, args):
+    return EvaluationResult(
+        result=expected == actual,
+        messages=[Message("Hallo")],
+        dsl_expected="{5, 5}",
+        dsl_actual="{4, 4}"
+    )

--- a/tests/exercises/echo-function/evaluation/evaluator.py
+++ b/tests/exercises/echo-function/evaluation/evaluator.py
@@ -1,3 +1,4 @@
+# noinspection PyUnresolvedReferences
 from evaluation_utils import EvaluationResult, Message
 
 
@@ -6,11 +7,11 @@ def evaluate(actual):
     return EvaluationResult(correct, "correct", actual, [Message("Hallo")])
 
 
-def evaluate_value(expected, actual, args):
+def evaluate_value(expected, actual):
     return EvaluationResult(expected == actual, expected, actual, [Message("Hallo")])
 
 
-def evaluate_value_dsl(expected, actual, args):
+def evaluate_value_dsl(expected, actual):
     return EvaluationResult(
         result=expected == actual,
         messages=[Message("Hallo")],

--- a/tests/exercises/echo-function/evaluation/programmed-dsl-no-haskell.tson
+++ b/tests/exercises/echo-function/evaluation/programmed-dsl-no-haskell.tson
@@ -1,0 +1,157 @@
+{
+  "tabs": [
+    {
+      "name": "Tab",
+      "runs": [
+        {
+          "contexts": [
+            {
+              "testcases": [
+                {
+                  "input": {
+                    "type": "function",
+                    "name": "echo",
+                    "arguments": [
+                      {
+                        "type": "text",
+                        "data": "input-2"
+                      }
+                    ]
+                  },
+                  "output": {
+                    "result": {
+                      "value": {
+                        "type": "text",
+                        "data": "input-2"
+                      },
+                      "evaluator": {
+                        "type": "programmed",
+                        "function": {
+                          "file": "Evaluator.java",
+                          "name": "evaluateValueDsl"
+                        },
+                        "language": "java"
+                      }
+                    }
+                  }
+                },
+                {
+                  "input": {
+                    "type": "function",
+                    "name": "echo",
+                    "arguments": [
+                      {
+                        "type": "text",
+                        "data": "input-3"
+                      }
+                    ]
+                  },
+                  "output": {
+                    "result": {
+                      "value": {
+                        "type": "text",
+                        "data": "input-3"
+                      },
+                      "evaluator": {
+                        "type": "programmed",
+                        "function": {
+                          "file": "evaluator.py",
+                          "name": "evaluate_value_dsl"
+                        },
+                        "language": "python"
+                      }
+                    }
+                  }
+                },
+                {
+                  "input": {
+                    "type": "function",
+                    "name": "echo",
+                    "arguments": [
+                      {
+                        "type": "text",
+                        "data": "input-4"
+                      }
+                    ]
+                  },
+                  "output": {
+                    "result": {
+                      "value": {
+                        "type": "text",
+                        "data": "input-4"
+                      },
+                      "evaluator": {
+                        "type": "programmed",
+                        "function": {
+                          "file": "evaluator.js",
+                          "name": "evaluateValueDsl"
+                        },
+                        "language": "javascript"
+                      }
+                    }
+                  }
+                },
+                {
+                  "input": {
+                    "type": "function",
+                    "name": "echo",
+                    "arguments": [
+                      {
+                        "type": "text",
+                        "data": "input-5"
+                      }
+                    ]
+                  },
+                  "output": {
+                    "result": {
+                      "value": {
+                        "type": "text",
+                        "data": "input-5"
+                      },
+                      "evaluator": {
+                        "type": "programmed",
+                        "function": {
+                          "file": "Evaluator.kt",
+                          "name": "evaluateValueDsl"
+                        },
+                        "language": "kotlin"
+                      }
+                    }
+                  }
+                },
+                {
+                  "input": {
+                    "type": "function",
+                    "name": "echo",
+                    "arguments": [
+                      {
+                        "type": "text",
+                        "data": "input-89"
+                      }
+                    ]
+                  },
+                  "output": {
+                    "result": {
+                      "value": {
+                        "type": "text",
+                        "data": "input-89"
+                      },
+                      "evaluator": {
+                        "type": "programmed",
+                        "function": {
+                          "file": "Evaluator.cs",
+                          "name": "EvaluateValueDsl"
+                        },
+                        "language": "csharp"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/exercises/echo/evaluation/evaluator.py
+++ b/tests/exercises/echo/evaluation/evaluator.py
@@ -1,9 +1,10 @@
+# noinspection PyUnresolvedReferences
 from evaluation_utils import EvaluationResult
 
 
-def evaluate_correct(expected, actual, arguments):
+def evaluate_correct(expected, actual):
     return EvaluationResult(expected.strip() == actual.strip())
 
 
-def evaluate_wrong(expected, actual, arguments):
+def evaluate_wrong(_expected, _actual):
     return EvaluationResult(False)

--- a/tests/exercises/lotto/evaluation/evaluator.py
+++ b/tests/exercises/lotto/evaluation/evaluator.py
@@ -1,4 +1,5 @@
 import re
+# noinspection PyUnresolvedReferences
 from evaluation_utils import EvaluationResult, Message
 
 
@@ -39,8 +40,7 @@ def valid_lottery_numbers(number_str, count=6, maximum=42):
     return True, None
 
 
-def evaluate(expected, actual, arguments):
-    count, maximum = arguments
+def evaluate(expected, actual, count, maximum):
     valid, message = valid_lottery_numbers(actual, count, maximum)
     messages = [Message(message)] if message else []
     if valid:

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -921,7 +921,7 @@ def test_expected_no_return_and_got_none(language: str, tmp_path: Path, pytestco
 
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
-    assert updates.find_status_enum() == ["correct"]
+    assert updates.find_status_enum() == []
 
 
 @pytest.mark.parametrize("language", ALL_SPECIFIC_LANGUAGES)

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -293,6 +293,25 @@ def test_programmed_evaluation(language: str, tmp_path: Path, pytestconfig):
     assert len(updates.find_all("append-message")) == 5
 
 
+def test_programmed_evaluation_with_dsl(tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "echo-function",
+        "javascript",
+        tmp_path,
+        "programmed-dsl-no-haskell.tson",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"] * 5
+    assert len(updates.find_all("append-message")) == 5
+    all_expected = [x["expected"] for x in updates.find_all("start-test")]
+    assert all_expected == ["new Set([5, 5])"] * 5
+    all_actual = [x["generated"] for x in updates.find_all("close-test")]
+    assert all_actual == ["new Set([4, 4])"] * 5
+
+
 @pytest.mark.parametrize(
     "lang",
     [

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -6,7 +6,7 @@ import tested
 from tested.configs import create_bundle
 from tested.datatypes import BasicObjectTypes, BasicSequenceTypes, BasicStringTypes
 from tested.dodona import Status
-from tested.oracles.common import OracleConfig, OracleResult
+from tested.oracles.common import OracleConfig
 from tested.oracles.exception import evaluate as evaluate_exception
 from tested.oracles.text import evaluate_file, evaluate_text
 from tested.oracles.value import evaluate as evaluate_value

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -194,7 +194,7 @@ def run_encoder(bundle: Bundle, values: list[Value]) -> list[str]:
     # Run the code.
     r = execute_file(bundle, executable.name, dest, None)
     print(r.stderr)
-    return r.stdout.splitlines(keepends=False)
+    return r.stdout.split(sep="␞")[:-1]
 
 
 def assert_serialisation(bundle: Bundle, expected: Value):


### PR DESCRIPTION
Currently, you can overwrite the expected and actual value using oracles. However, these overwritten values are "raw" strings and shown verbatim to the user. This makes it difficult to create a language-independent oracles, as you need to convert values to all programming languages yourself (and furthermore, you don't actually know for which language you are called).

This PR adds support for using the DSL Python-like syntax for these overwrites, meaning TESTed takes care of converting the values into the proper representation in the target programming language.