### PR TITLE
Enable definitions blocks in DSL for YAML anchor/alias/merge

### DIFF
--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -331,9 +331,6 @@
             "integer",
             "boolean"
           ]
-        },
-        "config" : {
-          "$ref" : "#/$defs/textConfigurationOptions"
         }
       },
       "oneOf" : [
@@ -344,6 +341,9 @@
               "enum" : [
                 "builtin"
               ]
+            },
+            "config" : {
+              "$ref" : "#/$defs/textConfigurationOptions"
             }
           }
         },

--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -40,10 +40,6 @@
       "type" : "object",
       "unevaluatedProperties" : false,
       "properties" : {
-        "config" : {
-          "$ref" : "#/$defs/globalConfig",
-          "description" : "Configuration applicable to the whole test suite."
-        },
         "files" : {
           "type" : "array",
           "items" : {
@@ -71,6 +67,10 @@
             }
           ],
           "default" : "tested"
+        },
+        "definitions": {
+          "description": "Define hashes to use elsewhere.",
+          "type": "object"
         }
       },
       "oneOf" : [
@@ -90,10 +90,6 @@
       "type" : "object",
       "unevaluatedProperties" : false,
       "properties" : {
-        "config" : {
-          "$ref" : "#/$defs/globalConfig",
-          "description" : "Configuration applicable to this unit/tab"
-        },
         "files" : {
           "type" : "array",
           "items" : {
@@ -123,6 +119,10 @@
         },
         "testcases" : {
           "$ref" : "#/$defs/_scriptList"
+        },
+        "definitions": {
+          "description": "Define hashes to use elsewhere.",
+          "type": "object"
         }
       },
       "oneOf" : [
@@ -166,10 +166,6 @@
       "type" : "object",
       "unevaluatedProperties" : false,
       "properties" : {
-        "config" : {
-          "$ref" : "#/$defs/globalConfig",
-          "description" : "Configuration settings at context level"
-        },
         "files" : {
           "type" : "array",
           "items" : {
@@ -279,10 +275,6 @@
         "stdout" : {
           "description" : "Expected output at stdout",
           "$ref" : "#/$defs/textOutputChannel"
-        },
-        "config" : {
-          "$ref" : "#/$defs/globalConfig",
-          "description" : "Configuration settings at testcase level"
         },
         "exit_code" : {
           "type" : "integer",
@@ -491,20 +483,6 @@
         "hideExpected" : {
           "description" : "Hide the expected value in feedback (default: false), not recommended to use!",
           "type" : "boolean"
-        }
-      }
-    },
-    "globalConfig" : {
-      "type" : "object",
-      "description" : "Global configuration properties",
-      "minProperties" : 1,
-      "unevaluatedProperties" : false,
-      "properties" : {
-        "stdout" : {
-          "$ref" : "#/$defs/textConfigurationOptions"
-        },
-        "stderr" : {
-          "$ref" : "#/$defs/textConfigurationOptions"
         }
       }
     },

--- a/tested/dsl/schema_draft7.json
+++ b/tested/dsl/schema_draft7.json
@@ -39,10 +39,6 @@
     "_rootObject" : {
       "type" : "object",
       "properties" : {
-        "config" : {
-          "$ref" : "#/definitions/globalConfig",
-          "description" : "Configuration applicable to the whole test suite."
-        },
         "files" : {
           "type" : "array",
           "items" : {
@@ -70,6 +66,10 @@
             }
           ],
           "default" : "tested"
+        },
+        "definitions": {
+          "description": "Define hashes to use elsewhere.",
+          "type": "object"
         }
       },
       "oneOf" : [
@@ -88,10 +88,6 @@
     "unit" : {
       "type" : "object",
       "properties" : {
-        "config" : {
-          "$ref" : "#/definitions/globalConfig",
-          "description" : "Configuration applicable to this unit/tab"
-        },
         "files" : {
           "type" : "array",
           "items" : {
@@ -121,6 +117,10 @@
         },
         "testcases" : {
           "$ref" : "#/definitions/_scriptList"
+        },
+        "definitions": {
+          "description": "Define hashes to use elsewhere.",
+          "type": "object"
         }
       },
       "oneOf" : [
@@ -163,10 +163,6 @@
     "testcase" : {
       "type" : "object",
       "properties" : {
-        "config" : {
-          "$ref" : "#/definitions/globalConfig",
-          "description" : "Configuration settings at context level"
-        },
         "files" : {
           "type" : "array",
           "items" : {
@@ -275,10 +271,6 @@
         "stdout" : {
           "description" : "Expected output at stdout",
           "$ref" : "#/definitions/textOutputChannel"
-        },
-        "config" : {
-          "$ref" : "#/definitions/globalConfig",
-          "description" : "Configuration settings at testcase level"
         },
         "exitCode" : {
           "type" : "integer",
@@ -484,19 +476,6 @@
         "hideExpected" : {
           "description" : "Hide the expected value in feedback (default: false), not recommended to use!",
           "type" : "boolean"
-        }
-      }
-    },
-    "globalConfig" : {
-      "type" : "object",
-      "description" : "Global configuration properties",
-      "minProperties" : 1,
-      "properties" : {
-        "stdout" : {
-          "$ref" : "#/definitions/textConfigurationOptions"
-        },
-        "stderr" : {
-          "$ref" : "#/definitions/textConfigurationOptions"
         }
       }
     },

--- a/tested/dsl/schema_draft7.json
+++ b/tested/dsl/schema_draft7.json
@@ -326,9 +326,6 @@
             "integer",
             "boolean"
           ]
-        },
-        "config" : {
-          "$ref" : "#/definitions/textConfigurationOptions"
         }
       },
       "oneOf" : [
@@ -339,6 +336,9 @@
               "enum" : [
                 "builtin"
               ]
+            },
+            "config" : {
+              "$ref" : "#/definitions/textConfigurationOptions"
             }
           }
         },


### PR DESCRIPTION
This PR enables a new object called `definitions` that can be used to define stuff and use it later:

```yaml
- unit: 'Sum of three cubes'
  definitions:
    sum_of_three: &sum_of_three
      oracle: 'custom_check'
      language: 'python'
      name: 'sum_of_three_cubes'
      file: 'oracle.py'
   a_value: &string_value "some string"
  testcases:
    - stdin: '3'
      stdout:
        <<: *sum_of_three
        data: |
          1
          1
          1
    - stdin: '33'
      stdout: *string_value
    - stdin: '42'
    - stdout:
        <<: *sum_of_three
        data: |
          -80538738812075974
          80435758145817515
          12602123297335631
```

This is done by using three YAML features:

- YAML anchors: this gives a name to a node (with `&name`)
- YAML aliases: this refers to an anchor (with `*name`)
- YAML merge key: this merges one hash with another (`<< *name`)

For example, this below will merge all attributes of the `sum_of_three` object with the `stdout` object:
```yaml
stdout:
  <<: *sum_of_three
  data: "example"
```

The example below is an alias: the `stdout` object will be the same as the `sum_of_three` object:
```yaml
stdout: *sum_of_three
```


Since this is purely YAML, you could also anchor the first use, instead of using the `definitions` object.

To be consistent, this PR also removes our own "inheritance" support for config values. The support for files is kept for now, as merging lists is not possible in a somewhat standard way (but we could introduce support for it with a custom tag at some point).

Closes #394.

