### PR TITLE
Improve messages for missing values and non-executed contexts

### DIFF
--- a/tested/internationalization/en.yaml
+++ b/tested/internationalization/en.yaml
@@ -58,13 +58,10 @@ en:
         source-code: "Invalid source code"
       initialization: "Error while initializing the code:"
     evaluation:
-      early-exit: "The evaluation has stopped early."
       time-limit: "Time limit exceeded"
       memory-limit: "Memory limit exceeded"
-      missing:
-        context: "Context not executed"
-        output: "Missing output"
-        test: "Test not executed"
+      not-executed: "These test(s) were not executed"
+      missing: "Missing result"
       files:
         zero: "No files"
         one: "File: %{files}"

--- a/tested/internationalization/nl.yaml
+++ b/tested/internationalization/nl.yaml
@@ -58,13 +58,10 @@ nl:
         source-code: "Ongeldige broncode"
       initialization: "Fout tijdens het initialiseren van de code:"
     evaluation:
-      early-exit: "De beoordeling is vroegtijdig gestopt."
-      time-limit: "Tijdslimiet overschreden."
-      memory-limit: "Geheugenlimiet overschreden."
-      missing:
-        context: "Context niet uitgevoerd"
-        output: "Ontbrekende uitvoer"
-        test: "Test niet uitgevoerd"
+      time-limit: "Tijdslimiet overschreden"
+      memory-limit: "Geheugenlimiet overschreden"
+      not-executed: "Deze test(en) werden niet uitgevoerd"
+      missing: "Ontbrekend resultaat"
       files:
         zero: "Geen bestanden"
         one: "Bestand: %{files}"


### PR DESCRIPTION
Fixes #436, fixes #342.

- Only add one message when something isn't executed.
- Don't mention internal structures; instead there is now a simple message that "Test(s) were not executed".