### PR TITLE
(Re)-add internal profiler

### DIFF
--- a/tested/configs.py
+++ b/tested/configs.py
@@ -64,6 +64,10 @@ class Options:
     Longer exercises, or exercises where the solution might depend on optimization
     may need this option.
     """
+    profile: bool = False
+    """
+    Profile the execution or not.
+    """
 
 
 @fallback_field(get_converter(), {"testplan": "test_suite", "plan_name": "test_suite"})

--- a/tested/judge/internal_profiler.py
+++ b/tested/judge/internal_profiler.py
@@ -1,0 +1,79 @@
+from time import monotonic
+
+from attr import define, field
+
+from tested.dodona import ExtendedMessage, Permission
+
+
+@define
+class Measurement:
+    name: str
+    start: float
+    end: float | None = None
+    nested: list["Measurement"] = field(factory=list)
+
+    def to_message(self, default_open: bool = False) -> str:
+        assert self.end
+        if self.nested:
+            nested_result = ""
+            for n in self.nested:
+                nested_result += n.to_message()
+                nested_result += "\n"
+            return f"""
+                    <details {"open" if default_open else ""}>
+                    <summary>{self.name}: {self.end - self.start:.2f}s</summary>
+                    <p>{nested_result}</p>
+                    </details>
+                    """
+        else:
+            return f"{self.name}: {self.end - self.start:.2f}s<br>"
+
+
+class Profiler:
+    root_measurement: Measurement
+    currently_open: list[Measurement]
+
+    def __init__(self):
+        self.root_measurement = Measurement(name="Execution", start=monotonic())
+        self.currently_open = [self.root_measurement]
+
+    def start(self, name: str):
+        measurement = Measurement(name=name, start=monotonic())
+        self.currently_open[-1].nested.append(measurement)
+        self.currently_open.append(measurement)
+
+    def stop(self, name: str):
+        assert (
+            self.currently_open[-1].name == name
+        ), f"Expected {self.currently_open[-1].name}, got {name}"
+        m = self.currently_open.pop()
+        m.end = monotonic()
+
+    def to_message(self) -> ExtendedMessage:
+        if not self.root_measurement.end:
+            self.root_measurement.end = monotonic()
+        return ExtendedMessage(
+            description=f"""
+            <h2>Time measurements</h2>
+            Note that enabling profiling disables parallel execution, if that was enabled.<br>
+            These measurements can be used to check which part of TESTed is using a lot of time.<br>
+            Measurements are rounded to .2f, so they might not add up.<br>
+            Not everything is measured: expect Dodona-reported execution to be longer.
+            <style>
+            details > *:not(summary) {{
+                margin-left: 2em;
+            }}
+            </style>
+            <p>{self.root_measurement.to_message(True)}</p>
+            """,
+            format="html",
+            permission=Permission.STAFF,
+        )
+
+
+class DummyProfiler:
+    def start(self, name: str):
+        pass
+
+    def stop(self, name: str):
+        pass

--- a/tested/main.py
+++ b/tested/main.py
@@ -6,6 +6,7 @@ from typing import IO
 
 from tested.configs import DodonaConfig, create_bundle
 from tested.dsl import parse_dsl
+from tested.judge.internal_profiler import DummyProfiler, Profiler
 from tested.testsuite import parse_test_suite
 
 
@@ -16,6 +17,11 @@ def run(config: DodonaConfig, judge_output: IO):
     :param config: The configuration, as received from Dodona.
     :param judge_output: Where the judge output will be written to.
     """
+    if config.options.profile:
+        profiler = Profiler()
+    else:
+        profiler = DummyProfiler()
+    profiler.start("Reading test suite")
     try:
         with open(f"{config.resources}/{config.test_suite}", "r") as t:
             textual_suite = t.read()
@@ -25,14 +31,17 @@ def run(config: DodonaConfig, judge_output: IO):
             "Remember that the test suite is a path relative to the 'evaluation' folder of your exercise."
         )
         raise e
+    profiler.stop("Reading test suite")
 
     _, ext = os.path.splitext(config.test_suite)
     is_yaml = ext.lower() in (".yaml", ".yml")
+    profiler.start("Parsing test suite")
     if is_yaml:
         suite = parse_dsl(textual_suite)
     else:
         suite = parse_test_suite(textual_suite)
+    profiler.stop("Parsing test suite")
     pack = create_bundle(config, judge_output, suite)
     from .judge import judge
 
-    judge(pack)
+    judge(pack, profiler)


### PR DESCRIPTION
Add a simplified version of #252.

These were removed in #323, as most issues could be found locally using a profiler. However, recently, discrepancies have appeared, necessitating the return of this module.

This is needed in the investigation of why https://dodona.be/nl/courses/2876/activities/300125229/ is very slow (30s+ runtime) while locally it takes about 0.2s.