### PR TITLE
Don't use .sh extension for Bash submission

### DIFF
--- a/tested/languages/bash/config.py
+++ b/tested/languages/bash/config.py
@@ -16,6 +16,7 @@ from tested.languages.conventionalize import (
     Conventionable,
     NamingConventions,
     submission_file,
+    submission_name,
 )
 from tested.serialisation import Statement, Value
 
@@ -49,6 +50,12 @@ class Bash(Language):
             Construct.DEFAULT_PARAMETERS,
             Construct.GLOBAL_VARIABLES,
         }
+
+    def is_source_file(self, file: Path) -> bool:
+        return file.suffix == ""
+
+    def submission_file(self) -> str:
+        return submission_name(self)
 
     def compilation(self, files: list[str]) -> CallbackResult:
         submission = submission_file(self)

--- a/tested/languages/bash/generators.py
+++ b/tested/languages/bash/generators.py
@@ -2,6 +2,7 @@ import shlex
 from collections.abc import Callable
 
 from tested.datatypes import AdvancedStringTypes, BasicStringTypes
+from tested.languages.conventionalize import submission_file
 from tested.languages.preparation import (
     PreparedContext,
     PreparedExecutionUnit,
@@ -200,7 +201,7 @@ touch {pu.value_file} {pu.exception_file}
 
         # Import the submission if there is no main call.
         if not ctx.context.has_main_testcase():
-            result += f"{indent}source {pu.submission_name}.sh\n"
+            result += f"{indent}source {submission_file(pu.language)}\n"
 
         # Generate code for each testcase
         tc: PreparedTestcase
@@ -210,7 +211,7 @@ touch {pu.value_file} {pu.exception_file}
             # Prepare command arguments if needed.
             if tc.testcase.is_main_testcase():
                 assert isinstance(tc.input, MainInput)
-                result += f"{indent}bash {pu.submission_name}.sh "
+                result += f"{indent}bash {submission_file(pu.language)} "
                 result += " ".join(shlex.quote(s) for s in tc.input.arguments) + "\n"
             else:
                 assert isinstance(tc.input, PreparedTestcaseStatement)

--- a/tested/languages/config.py
+++ b/tested/languages/config.py
@@ -19,6 +19,7 @@ from tested.languages.conventionalize import (
     Conventionable,
     NamingConventions,
     conventionalize_namespace,
+    submission_name,
 )
 from tested.serialisation import FunctionCall, Statement, Value
 
@@ -199,6 +200,12 @@ class Language(ABC):
         :return: The file name with the language's extension appended to it.
         """
         return f"{file_name}.{self.file_extension()}"
+
+    def submission_file(self) -> str:
+        """
+        :return: The name of the submission.
+        """
+        return self.with_extension(submission_name(self))
 
     @abstractmethod
     def initial_dependencies(self) -> list[str]:

--- a/tested/languages/conventionalize.py
+++ b/tested/languages/conventionalize.py
@@ -425,7 +425,7 @@ def submission_file(language: "Language") -> str:
     """
     :return: The file name of a submission.
     """
-    return language.with_extension(submission_name(language))
+    return language.submission_file()
 
 
 def selector_name(language: "Language") -> str:

--- a/tested/languages/javascript/generators.py
+++ b/tested/languages/javascript/generators.py
@@ -11,6 +11,7 @@ from tested.datatypes import (
     BasicSequenceTypes,
     BasicStringTypes,
 )
+from tested.languages.conventionalize import submission_file
 from tested.languages.preparation import (
     PreparedContext,
     PreparedExecutionUnit,
@@ -132,8 +133,8 @@ def _generate_internal_context(ctx: PreparedContext, pu: PreparedExecutionUnit) 
     # Import the submission if there is no main call.
     if not ctx.context.has_main_testcase():
         result += f"""
-            delete require.cache[require.resolve("./{pu.submission_name}.js")];
-            const {pu.submission_name} = require("./{pu.submission_name}.js");
+            delete require.cache[require.resolve("./{submission_file(pu.language)}")];
+            const {pu.submission_name} = require("./{submission_file(pu.language)}");
             """
 
     # Generate code for each testcase

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -203,7 +203,7 @@ def test_java_runtime_error():
 
 
 def test_bash_runtime_error():
-    original = "submission.sh: rule 1: d: opdracht niet gevonden\n"
+    original = "submission: rule 1: d: opdracht niet gevonden\n"
     language_config = get_language("test", "bash")
     expected = "<code>:1: d: opdracht niet gevonden\n"
     actual = language_config.cleanup_stacktrace(original)
@@ -212,8 +212,8 @@ def test_bash_runtime_error():
 
 def test_bash_compilation_error():
     original = """
-    submission.sh: rule 1: syntaxfout nabij onverwacht symbool '('
-    submission.sh: rule 1: `def isISBN10(code):'
+    submission: rule 1: syntaxfout nabij onverwacht symbool '('
+    submission: rule 1: `def isISBN10(code):'
     """
     language_config = get_language("test", "bash")
     expected = """


### PR DESCRIPTION
This makes Bash more in line with other languages (as we pass the `$0` argument there manually, also without extension).

Fixes #467 