### PR TITLE
Fix bug for stdout/stderrr on timeouts

### DIFF
--- a/tested/judge/planning.py
+++ b/tested/judge/planning.py
@@ -46,7 +46,8 @@ class PlannedExecutionUnit:
     index: int
 
     def get_stdin(self, resources: Path) -> str:
-        return "\n".join(c.context.get_stdin(resources) or "" for c in self.contexts)
+        potential = [c.context.get_stdin(resources) for c in self.contexts]
+        return "\n".join(p for p in potential if p)
 
     def has_main_testcase(self) -> bool:
         return self.contexts[0].context.has_main_testcase()

--- a/tested/judge/utils.py
+++ b/tested/judge/utils.py
@@ -60,8 +60,8 @@ def run_command(
         )
     except subprocess.TimeoutExpired as e:
         return BaseExecutionResult(
-            stdout=str(e.stdout or ""),
-            stderr=str(e.stderr or ""),
+            stdout=e.stdout.decode("utf-8", "backslashreplace") if e.stdout else "",
+            stderr=e.stderr.decode("utf-8", "backslashreplace") if e.stderr else "",
             exit=0,
             timeout=True,
             memory=False,


### PR DESCRIPTION
When a timeout occurs, we catch the exception and attempt to recover existing stdout/stderr. However, the [docs](https://docs.python.org/3/library/subprocess.html#subprocess.TimeoutExpired) specify that these are `bytes`, even if `text=True`.

We must therefore properly decode these bytes instead of just passing them to `str`.

Fixes #476.