### PR TITLE
Better escape command line arguments

### DIFF
--- a/tested/languages/bash/generators.py
+++ b/tested/languages/bash/generators.py
@@ -212,7 +212,7 @@ touch {pu.value_file} {pu.exception_file}
                 result += indent + "write_separator\n"
                 assert isinstance(tc.input, MainInput)
                 result += f"{indent}bash {submission_file(pu.language)} "
-                result += " ".join(shlex.quote(s) for s in tc.input.arguments) + "\n"
+                result += shlex.join(tc.input.arguments) + "\n"
             else:
                 if j != 0:
                     result += indent + "write_separator\n"

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -89,15 +89,6 @@ def _handle_link_files(link_files: Iterable[FileUrl], language: str) -> tuple[st
     )
 
 
-def _escape_shell(arg: str) -> str:
-    # We want to always quote...
-    quoted = shlex.quote(arg)
-    if quoted.startswith("'") and quoted.endswith("'"):
-        return quoted
-    else:
-        return f"'{quoted}'"
-
-
 def get_readable_input(
     bundle: Bundle, case: Testcase
 ) -> tuple[ExtendedMessage, set[FileUrl]]:
@@ -122,9 +113,9 @@ def get_readable_input(
         assert isinstance(case.input, MainInput)
         # See https://rouge-ruby.github.io/docs/Rouge/Lexers/ConsoleLexer.html
         format_ = "console"
-        arguments = " ".join(_escape_shell(x) for x in case.input.arguments)
         submission = submission_name(bundle.language)
-        args = f"$ {submission} {arguments}"
+        command = shlex.join([submission] + case.input.arguments)
+        args = f"$ {command}"
         if isinstance(case.input.stdin, TextData):
             stdin = case.input.stdin.get_data_as_string(bundle.config.resources)
         else:


### PR DESCRIPTION
Instead of using `shlex.quote` and then manually joining commands, use `shlex.join`, which has better results, especially for flags and other options.

Fix #480.