### PR TITLE
Use here-doc for stdin if both stdin and arguments are used

### DIFF
--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -90,6 +90,13 @@ YamlObject = (
 )
 
 
+def _ensure_trailing_newline(text: str) -> str:
+    if text[-1] != "\n":
+        return text + "\n"
+    else:
+        return text
+
+
 def _parse_yaml_value(loader: yaml.Loader, node: yaml.Node) -> Any:
     if isinstance(node, yaml.MappingNode):
         result = loader.construct_mapping(node)
@@ -442,7 +449,7 @@ def _convert_testcase(testcase: YamlDict, context: DslContext) -> Testcase:
     else:
         if "stdin" in testcase:
             assert isinstance(testcase["stdin"], str)
-            stdin = TextData(data=testcase["stdin"])
+            stdin = TextData(data=_ensure_trailing_newline(testcase["stdin"]))
         else:
             stdin = EmptyChannel.NONE
         arguments = testcase.get("arguments", [])

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -62,7 +62,7 @@ tabs:
     assert len(context.testcases) == 1
     tc = context.testcases[0]
     assert tc.is_main_testcase()
-    assert tc.input.stdin.data == "Input string"
+    assert tc.input.stdin.data == "Input string\n"
     assert tc.input.arguments == ["--arg", "argument"]
     assert tc.output.stderr.data == "Error string"
     assert tc.output.stdout.data == "Output string"


### PR DESCRIPTION
Currently, we just add the stdin below the command that is executed, which is not clear at all. We now use here-doc to display stdin in that case.

If only stdin is used, nothing changes: only stdin is shown.

It looks like this:
![image](https://github.com/dodona-edu/universal-judge/assets/1756811/a76e5622-cbcb-4fcc-bb00-037bc017b554)


The colouring is sometimes a bit wonky, both Rouge and Pygments are not that good at highlighting here-docs.

Fixes #484.