### PR TITLE
Enable strict text checking by default

### DIFF
--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -456,6 +456,10 @@
           "description" : "Ignore trailing whitespace",
           "type" : "boolean"
         },
+        "normalizeTrailingNewlines": {
+          "description": "Normalize trailing newlines",
+          "type": "boolean"
+        },
         "roundTo" : {
           "description" : "The number of decimals to round at, when applying the rounding on floats",
           "type" : "integer"

--- a/tested/dsl/schema_draft7.json
+++ b/tested/dsl/schema_draft7.json
@@ -449,6 +449,10 @@
           "description" : "Ignore trailing whitespace",
           "type" : "boolean"
         },
+        "normalizeTrailingNewlines": {
+          "description": "Normalize trailing newlines",
+          "type": "boolean"
+        },
         "roundTo" : {
           "description" : "The number of decimals to round at, when applying the rounding on floats",
           "type" : "integer"

--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -359,17 +359,20 @@ def _convert_custom_check_oracle(stream: dict) -> CustomCheckOracle:
 
 def _convert_text_output_channel(stream: YamlObject) -> TextOutputChannel:
     if isinstance(stream, str):
-        data = stream
+        data = _ensure_trailing_newline(stream)
         return TextOutputChannel(data=data, oracle=GenericTextOracle())
     else:
         assert isinstance(stream, dict)
         data = str(stream["data"])
         if "oracle" not in stream or stream["oracle"] == "builtin":
             config = cast(dict, stream.get("config", {}))
+            if config.get("normalizeTrailingNewlines", True):
+                data = _ensure_trailing_newline(data)
             return TextOutputChannel(
                 data=data, oracle=GenericTextOracle(options=config)
             )
         elif stream["oracle"] == "custom_check":
+            data = _ensure_trailing_newline(data)
             return TextOutputChannel(
                 data=data, oracle=_convert_custom_check_oracle(stream)
             )

--- a/tested/judge/planning.py
+++ b/tested/judge/planning.py
@@ -47,7 +47,7 @@ class PlannedExecutionUnit:
 
     def get_stdin(self, resources: Path) -> str:
         potential = [c.context.get_stdin(resources) for c in self.contexts]
-        return "\n".join(p for p in potential if p)
+        return "".join(p for p in potential if p)
 
     def has_main_testcase(self) -> bool:
         return self.contexts[0].context.has_main_testcase()

--- a/tested/oracles/text.py
+++ b/tested/oracles/text.py
@@ -20,12 +20,14 @@ def _is_number(string: str) -> float | None:
 def _text_options(config: OracleConfig) -> dict:
     defaults = {
         # Options for textual comparison
-        "ignoreWhitespace": True,
+        "ignoreWhitespace": False,
         "caseInsensitive": False,
         # Options for numerical comparison
         "tryFloatingPoint": False,
         "applyRounding": False,
         "roundTo": 3,
+        # This option is used in the DSL, no in the actual oracle.
+        "normalizeTrailingNewlines": True,
     }
     defaults.update(config.options)
     return defaults

--- a/tested/oracles/text.py
+++ b/tested/oracles/text.py
@@ -55,9 +55,9 @@ def compare_text(options: dict[str, Any], expected: str, actual: str) -> OracleR
 
     if (
         options["tryFloatingPoint"]
-        and (actual_float := _is_number(actual_eval)) is not None
+        and (actual_float := _is_number(actual_eval.strip())) is not None
     ):
-        expected_float = float(expected_eval)
+        expected_float = float(expected_eval.strip())
         if options["applyRounding"]:
             numbers = int(options["roundTo"])
             # noinspection PyUnboundLocalVariable

--- a/tests/exercises/echo/evaluation/full.tson
+++ b/tests/exercises/echo/evaluation/full.tson
@@ -7,13 +7,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-0",
+                "data": "invoertekst-0\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-0",
+                "data": "invoertekst-0\n",
                 "type": "text"
               },
               "main_call": true
@@ -24,13 +24,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-1",
+                "data": "invoertekst-1\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-1",
+                "data": "invoertekst-1\n",
                 "type": "text"
               },
               "main_call": true
@@ -41,13 +41,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-2",
+                "data": "invoertekst-2\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-2",
+                "data": "invoertekst-2\n",
                 "type": "text"
               },
               "main_call": true
@@ -58,13 +58,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-3",
+                "data": "invoertekst-3\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-3",
+                "data": "invoertekst-3\n",
                 "type": "text"
               },
               "main_call": true
@@ -75,13 +75,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-4",
+                "data": "invoertekst-4\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-4",
+                "data": "invoertekst-4\n",
                 "type": "text"
               },
               "main_call": true
@@ -92,13 +92,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-5",
+                "data": "invoertekst-5\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-5",
+                "data": "invoertekst-5\n",
                 "type": "text"
               },
               "main_call": true
@@ -109,13 +109,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-6",
+                "data": "invoertekst-6\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-6",
+                "data": "invoertekst-6\n",
                 "type": "text"
               },
               "main_call": true
@@ -126,13 +126,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-7",
+                "data": "invoertekst-7\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-7",
+                "data": "invoertekst-7\n",
                 "type": "text"
               },
               "main_call": true
@@ -143,13 +143,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-8",
+                "data": "invoertekst-8\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-8",
+                "data": "invoertekst-8\n",
                 "type": "text"
               },
               "main_call": true
@@ -160,13 +160,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-9",
+                "data": "invoertekst-9\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-9",
+                "data": "invoertekst-9\n",
                 "type": "text"
               },
               "main_call": true
@@ -177,13 +177,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-10",
+                "data": "invoertekst-0\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-10",
+                "data": "invoertekst-0\n",
                 "type": "text"
               },
               "main_call": true
@@ -194,13 +194,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-11",
+                "data": "invoertekst-1\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-11",
+                "data": "invoertekst-1\n",
                 "type": "text"
               },
               "main_call": true
@@ -211,13 +211,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-12",
+                "data": "invoertekst-2\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-12",
+                "data": "invoertekst-2\n",
                 "type": "text"
               },
               "main_call": true
@@ -228,13 +228,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-13",
+                "data": "invoertekst-3\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-13",
+                "data": "invoertekst-3\n",
                 "type": "text"
               },
               "main_call": true
@@ -245,13 +245,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-14",
+                "data": "invoertekst-4\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-14",
+                "data": "invoertekst-4\n",
                 "type": "text"
               },
               "main_call": true
@@ -262,13 +262,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-15",
+                "data": "invoertekst-5\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-15",
+                "data": "invoertekst-5\n",
                 "type": "text"
               },
               "main_call": true
@@ -279,13 +279,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-16",
+                "data": "invoertekst-6\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-16",
+                "data": "invoertekst-6\n",
                 "type": "text"
               },
               "main_call": true
@@ -296,13 +296,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-17",
+                "data": "invoertekst-7\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-17",
+                "data": "invoertekst-7\n",
                 "type": "text"
               },
               "main_call": true
@@ -313,13 +313,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-18",
+                "data": "invoertekst-8\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-18",
+                "data": "invoertekst-8\n",
                 "type": "text"
               },
               "main_call": true
@@ -330,13 +330,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-19",
+                "data": "invoertekst-9\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-19",
+                "data": "invoertekst-9\n",
                 "type": "text"
               },
               "main_call": true
@@ -347,13 +347,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-20",
+                "data": "invoertekst-0\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-20",
+                "data": "invoertekst-0\n",
                 "type": "text"
               },
               "main_call": true
@@ -364,13 +364,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-21",
+                "data": "invoertekst-1\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-21",
+                "data": "invoertekst-1\n",
                 "type": "text"
               },
               "main_call": true
@@ -381,13 +381,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-22",
+                "data": "invoertekst-2\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-22",
+                "data": "invoertekst-2\n",
                 "type": "text"
               },
               "main_call": true
@@ -398,13 +398,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-23",
+                "data": "invoertekst-3\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-23",
+                "data": "invoertekst-3\n",
                 "type": "text"
               },
               "main_call": true
@@ -415,13 +415,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-24",
+                "data": "invoertekst-4\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-24",
+                "data": "invoertekst-4\n",
                 "type": "text"
               },
               "main_call": true
@@ -432,13 +432,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-25",
+                "data": "invoertekst-5\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-25",
+                "data": "invoertekst-5\n",
                 "type": "text"
               },
               "main_call": true
@@ -449,13 +449,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-26",
+                "data": "invoertekst-6\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-26",
+                "data": "invoertekst-6\n",
                 "type": "text"
               },
               "main_call": true
@@ -466,13 +466,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-27",
+                "data": "invoertekst-7\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-27",
+                "data": "invoertekst-7\n",
                 "type": "text"
               },
               "main_call": true
@@ -483,13 +483,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-28",
+                "data": "invoertekst-8\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-28",
+                "data": "invoertekst-8\n",
                 "type": "text"
               },
               "main_call": true
@@ -500,13 +500,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-29",
+                "data": "invoertekst-9\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-29",
+                "data": "invoertekst-9\n",
                 "type": "text"
               },
               "main_call": true
@@ -517,13 +517,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-30",
+                "data": "invoertekst-0\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-30",
+                "data": "invoertekst-0\n",
                 "type": "text"
               },
               "main_call": true
@@ -534,13 +534,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-31",
+                "data": "invoertekst-1\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-31",
+                "data": "invoertekst-1\n",
                 "type": "text"
               },
               "main_call": true
@@ -551,13 +551,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-32",
+                "data": "invoertekst-2\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-32",
+                "data": "invoertekst-2\n",
                 "type": "text"
               },
               "main_call": true
@@ -568,13 +568,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-33",
+                "data": "invoertekst-3\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-33",
+                "data": "invoertekst-3\n",
                 "type": "text"
               },
               "main_call": true
@@ -585,13 +585,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-34",
+                "data": "invoertekst-4\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-34",
+                "data": "invoertekst-4\n",
                 "type": "text"
               },
               "main_call": true
@@ -602,13 +602,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-35",
+                "data": "invoertekst-5\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-35",
+                "data": "invoertekst-5\n",
                 "type": "text"
               },
               "main_call": true
@@ -619,13 +619,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-36",
+                "data": "invoertekst-6\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-36",
+                "data": "invoertekst-6\n",
                 "type": "text"
               },
               "main_call": true
@@ -636,13 +636,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-37",
+                "data": "invoertekst-7\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-37",
+                "data": "invoertekst-7\n",
                 "type": "text"
               },
               "main_call": true
@@ -653,13 +653,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-38",
+                "data": "invoertekst-8\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-38",
+                "data": "invoertekst-8\n",
                 "type": "text"
               },
               "main_call": true
@@ -670,13 +670,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-39",
+                "data": "invoertekst-9\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-39",
+                "data": "invoertekst-9\n",
                 "type": "text"
               },
               "main_call": true
@@ -687,13 +687,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-40",
+                "data": "invoertekst-0\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-40",
+                "data": "invoertekst-0\n",
                 "type": "text"
               },
               "main_call": true
@@ -704,13 +704,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-41",
+                "data": "invoertekst-1\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-41",
+                "data": "invoertekst-1\n",
                 "type": "text"
               },
               "main_call": true
@@ -721,13 +721,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-42",
+                "data": "invoertekst-2\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-42",
+                "data": "invoertekst-2\n",
                 "type": "text"
               },
               "main_call": true
@@ -738,13 +738,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-43",
+                "data": "invoertekst-3\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-43",
+                "data": "invoertekst-3\n",
                 "type": "text"
               },
               "main_call": true
@@ -755,13 +755,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-44",
+                "data": "invoertekst-4\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-44",
+                "data": "invoertekst-4\n",
                 "type": "text"
               },
               "main_call": true
@@ -772,13 +772,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-45",
+                "data": "invoertekst-5\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-45",
+                "data": "invoertekst-5\n",
                 "type": "text"
               },
               "main_call": true
@@ -789,13 +789,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-46",
+                "data": "invoertekst-6\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-46",
+                "data": "invoertekst-6\n",
                 "type": "text"
               },
               "main_call": true
@@ -806,13 +806,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-47",
+                "data": "invoertekst-7\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-47",
+                "data": "invoertekst-7\n",
                 "type": "text"
               },
               "main_call": true
@@ -823,13 +823,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-48",
+                "data": "invoertekst-8\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-48",
+                "data": "invoertekst-8\n",
                 "type": "text"
               },
               "main_call": true
@@ -840,13 +840,13 @@
           "run": {
             "output": {
               "stdout": {
-                "data": "invoertekst-49",
+                "data": "invoertekst-9\n",
                 "type": "text"
               }
             },
             "input": {
               "stdin": {
-                "data": "invoertekst-49",
+                "data": "invoertekst-9\n",
                 "type": "text"
               },
               "main_call": true

--- a/tests/exercises/echo/evaluation/one.tson
+++ b/tests/exercises/echo/evaluation/one.tson
@@ -10,13 +10,13 @@
                 "main_call": true,
                 "stdin": {
                   "type": "text",
-                  "data": "input-1"
+                  "data": "input-1\n"
                 }
               },
               "output": {
                 "stdout": {
                   "type": "text",
-                  "data": "input-1"
+                  "data": "input-1\n"
                 }
               }
             }

--- a/tests/exercises/echo/evaluation/two.tson
+++ b/tests/exercises/echo/evaluation/two.tson
@@ -9,13 +9,13 @@
               "main_call": true,
               "stdin": {
                 "type": "text",
-                "data": "input-1"
+                "data": "input-1\n"
               }
             },
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "input-1"
+                "data": "input-1\n"
               }
             }
           }
@@ -26,13 +26,13 @@
               "main_call": true,
               "stdin": {
                 "type": "text",
-                "data": "input-2"
+                "data": "input-2\n"
               }
             },
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "input-2"
+                "data": "input-2\n"
               }
             }
           }

--- a/tests/exercises/echo/solution/correct.cs
+++ b/tests/exercises/echo/solution/correct.cs
@@ -1,2 +1,2 @@
 ﻿string line = Console.ReadLine();
-Console.Write(line);
+Console.WriteLine(line);

--- a/tests/exercises/echo/solution/correct.js
+++ b/tests/exercises/echo/solution/correct.js
@@ -1,3 +1,3 @@
 const fs = require("fs");
 const stdinBuffer = fs.readFileSync(0); // STDIN_FILENO = 0
-console.log(stdinBuffer.toString());
+console.log(stdinBuffer.toString().trimEnd());

--- a/tests/exercises/sum/evaluation/plan.tson
+++ b/tests/exercises/sum/evaluation/plan.tson
@@ -21,7 +21,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "127"
+                "data": "127\n"
               }
             }
           }
@@ -37,7 +37,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "22"
+                "data": "22\n"
               }
             }
           }
@@ -61,7 +61,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-187"
+                "data": "-187\n"
               }
             }
           }
@@ -75,7 +75,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               }
             }
           }
@@ -100,7 +100,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-41"
+                "data": "-41\n"
               }
             }
           }
@@ -122,7 +122,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "110"
+                "data": "110\n"
               }
             }
           }
@@ -141,7 +141,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-201"
+                "data": "-201\n"
               }
             }
           }
@@ -163,7 +163,7 @@
             "output": {
               "stderr": {
                 "type": "text",
-                "data": "som: ongeldige argumenten"
+                "data": "som: ongeldige argumenten\n"
               },
               "exit_code": {
                 "value": 1
@@ -185,7 +185,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "25"
+                "data": "25\n"
               }
             }
           }
@@ -204,7 +204,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-2"
+                "data": "-2\n"
               }
             }
           }
@@ -220,7 +220,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-2"
+                "data": "-2\n"
               }
             }
           }
@@ -241,7 +241,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-32"
+                "data": "-32\n"
               }
             }
           }
@@ -263,7 +263,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-5"
+                "data": "-5\n"
               }
             }
           }
@@ -282,7 +282,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "69"
+                "data": "69\n"
               }
             }
           }
@@ -306,7 +306,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "38"
+                "data": "38\n"
               }
             }
           }
@@ -327,7 +327,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "80"
+                "data": "80\n"
               }
             }
           }
@@ -352,7 +352,7 @@
             "output": {
               "stderr": {
                 "type": "text",
-                "data": "som: ongeldige argumenten"
+                "data": "som: ongeldige argumenten\n"
               },
               "exit_code": {
                 "value": 1
@@ -375,7 +375,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "25"
+                "data": "25\n"
               }
             }
           }
@@ -396,7 +396,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "205"
+                "data": "205\n"
               }
             }
           }
@@ -413,7 +413,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-58"
+                "data": "-58\n"
               }
             }
           }
@@ -432,7 +432,7 @@
             "output": {
               "stderr": {
                 "type": "text",
-                "data": "som: ongeldige argumenten"
+                "data": "som: ongeldige argumenten\n"
               },
               "exit_code": {
                 "value": 1
@@ -456,7 +456,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "296"
+                "data": "296\n"
               }
             }
           }
@@ -474,7 +474,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "77"
+                "data": "77\n"
               }
             }
           }
@@ -495,7 +495,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-53"
+                "data": "-53\n"
               }
             }
           }
@@ -517,7 +517,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-121"
+                "data": "-121\n"
               }
             }
           }
@@ -536,7 +536,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "145"
+                "data": "145\n"
               }
             }
           }
@@ -560,7 +560,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-204"
+                "data": "-204\n"
               }
             }
           }
@@ -577,7 +577,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-139"
+                "data": "-139\n"
               }
             }
           }
@@ -601,7 +601,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "108"
+                "data": "108\n"
               }
             }
           }
@@ -624,7 +624,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "27"
+                "data": "27\n"
               }
             }
           }
@@ -640,7 +640,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "66"
+                "data": "66\n"
               }
             }
           }
@@ -654,7 +654,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               }
             }
           }
@@ -678,7 +678,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-158"
+                "data": "-158\n"
               }
             }
           }
@@ -695,7 +695,7 @@
             "output": {
               "stderr": {
                 "type": "text",
-                "data": "som: ongeldige argumenten"
+                "data": "som: ongeldige argumenten\n"
               },
               "exit_code": {
                 "value": 1
@@ -718,7 +718,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-79"
+                "data": "-79\n"
               }
             }
           }
@@ -732,7 +732,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               }
             }
           }
@@ -746,7 +746,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               }
             }
           }
@@ -769,7 +769,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "119"
+                "data": "119\n"
               }
             }
           }
@@ -793,7 +793,7 @@
             "output": {
               "stderr": {
                 "type": "text",
-                "data": "som: ongeldige argumenten"
+                "data": "som: ongeldige argumenten\n"
               },
               "exit_code": {
                 "value": 1
@@ -819,7 +819,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-70"
+                "data": "-70\n"
               }
             }
           }
@@ -837,7 +837,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "107"
+                "data": "107\n"
               }
             }
           }
@@ -851,7 +851,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               }
             }
           }
@@ -875,7 +875,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "47"
+                "data": "47\n"
               }
             }
           }
@@ -898,7 +898,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-61"
+                "data": "-61\n"
               }
             }
           }
@@ -919,7 +919,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "-74"
+                "data": "-74\n"
               }
             }
           }
@@ -943,7 +943,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "35"
+                "data": "35\n"
               }
             }
           }
@@ -957,7 +957,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               }
             }
           }
@@ -981,7 +981,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "86"
+                "data": "86\n"
               }
             }
           }
@@ -1006,7 +1006,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "284"
+                "data": "284\n"
               }
             }
           }
@@ -1023,7 +1023,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "57"
+                "data": "57\n"
               }
             }
           }

--- a/tests/exercises/sum/evaluation/short.tson
+++ b/tests/exercises/sum/evaluation/short.tson
@@ -12,7 +12,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "127"
+                "data": "127\n"
               },
               "exit_code": {
                 "value": 0
@@ -29,7 +29,7 @@
             "output": {
               "stdout": {
                 "type": "text",
-                "data": "0"
+                "data": "0\n"
               },
               "exit_code": {
                 "value": 0
@@ -46,7 +46,7 @@
             "output": {
               "stderr": {
                 "type": "text",
-                "data": "som: ongeldige argumenten"
+                "data": "som: ongeldige argumenten\n"
               },
               "exit_code": {
                 "value": 1

--- a/tests/exercises/sum/solution/correct.c
+++ b/tests/exercises/sum/solution/correct.c
@@ -34,11 +34,11 @@ int main(int argc, char** argv) {
         if (result == 0) {
             sum += number;
         } else {
-            fprintf(stderr, "som: ongeldige argumenten");
+            fprintf(stderr, "som: ongeldige argumenten\n");
             exit(1);
         }
     }
 
-    printf("%ld", sum);
+    printf("%ld\n", sum);
     exit(0);
 }

--- a/tests/exercises/sum/solution/correct.py
+++ b/tests/exercises/sum/solution/correct.py
@@ -6,7 +6,7 @@ for getal in sys.argv[1:]:
     try:
         som += int(getal)
     except ValueError:
-        sys.stderr.write("som: ongeldige argumenten")
+        sys.stderr.write("som: ongeldige argumenten\n")
         exit(1)
 
 print(som)

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -64,8 +64,8 @@ tabs:
     assert tc.is_main_testcase()
     assert tc.input.stdin.data == "Input string\n"
     assert tc.input.arguments == ["--arg", "argument"]
-    assert tc.output.stderr.data == "Error string"
-    assert tc.output.stdout.data == "Output string"
+    assert tc.output.stderr.data == "Error string\n"
+    assert tc.output.stdout.data == "Output string\n"
     assert tc.output.exit_code.value == 1
 
 
@@ -217,7 +217,7 @@ def test_parse_ctx_with_config():
     assert tc3.input.arguments == ["-e"]
 
     stdout = tc0.output.stdout
-    assert stdout.data == "3.34"
+    assert stdout.data == "3.34\n"
     options = stdout.oracle.options
     assert len(options) == 3
     assert options["tryFloatingPoint"]
@@ -225,7 +225,7 @@ def test_parse_ctx_with_config():
     assert options["roundTo"] == 2
 
     stdout = tc1.output.stdout
-    assert stdout.data == "3.337"
+    assert stdout.data == "3.337\n"
     options = stdout.oracle.options
     assert len(options) == 3
     assert options["tryFloatingPoint"]
@@ -233,7 +233,7 @@ def test_parse_ctx_with_config():
     assert options["roundTo"] == 3
 
     stdout = tc2.output.stdout
-    assert stdout.data == "3.3"
+    assert stdout.data == "3.3\n"
     options = stdout.oracle.options
     assert len(options) == 3
     assert options["tryFloatingPoint"]
@@ -241,7 +241,7 @@ def test_parse_ctx_with_config():
     assert options["roundTo"] == 2
 
     stderr = tc3.output.stderr
-    assert stderr.data == " Fail "
+    assert stderr.data == " Fail \n"
     options = stderr.oracle.options
     assert len(options) == 2
     assert not options["caseInsensitive"]
@@ -282,14 +282,14 @@ def test_statements():
 
     assert len(tests0) == 2
     assert isinstance(tests0[0].input, Assignment)
-    assert tests0[0].output.stdout.data == "New safe"
+    assert tests0[0].output.stdout.data == "New safe\n"
     assert tests0[0].output.stdout.oracle.options["ignoreWhitespace"]
     assert isinstance(tests0[1].input, FunctionCall)
     assert tests0[1].output.result.value.data == "Ignore whitespace"
 
     assert len(tests1) == 2
     assert isinstance(tests1[0].input, Assignment)
-    assert tests1[0].output.stdout.data == "New safe"
+    assert tests1[0].output.stdout.data == "New safe\n"
     assert not tests1[0].output.stdout.oracle.options["ignoreWhitespace"]
     assert isinstance(tests1[1].input, FunctionCall)
     assert tests1[1].output.result.value.data == 5
@@ -318,7 +318,7 @@ def test_expression_and_main():
     assert len(ctx.testcases) == 2
     tc = ctx.testcases[0]
     assert tc.input.arguments == ["-a", "5", "7"]
-    assert tc.output.stdout.data == "12"
+    assert tc.output.stdout.data == "12\n"
     assert tc.output.stdout.oracle.options["tryFloatingPoint"]
     test = ctx.testcases[1]
     assert isinstance(test.input, FunctionCall)
@@ -559,7 +559,7 @@ def test_text_built_in_checks_implied():
     assert isinstance(test.input, FunctionCall)
     assert isinstance(test.output.stdout, TextOutputChannel)
     assert isinstance(test.output.stdout.oracle, GenericTextOracle)
-    assert test.output.stdout.data == "hallo"
+    assert test.output.stdout.data == "hallo\n"
 
 
 def test_text_built_in_checks_explicit():
@@ -583,7 +583,7 @@ def test_text_built_in_checks_explicit():
     assert isinstance(test.input, FunctionCall)
     assert isinstance(test.output.stdout, TextOutputChannel)
     assert isinstance(test.output.stdout.oracle, GenericTextOracle)
-    assert test.output.stdout.data == "hallo"
+    assert test.output.stdout.data == "hallo\n"
 
 
 def test_text_custom_checks_correct():
@@ -610,7 +610,7 @@ def test_text_custom_checks_correct():
     assert isinstance(test.input, FunctionCall)
     assert isinstance(test.output.stdout, TextOutputChannel)
     assert isinstance(test.output.stdout.oracle, CustomCheckOracle)
-    assert test.output.stdout.data == "hallo"
+    assert test.output.stdout.data == "hallo\n"
     oracle = test.output.stdout.oracle
     assert oracle.function.name == "evaluate_test"
     assert oracle.function.file == Path("test.py")

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -994,3 +994,95 @@ def test_files_are_propagated():
         FileUrl(name="test", url="test.md"),
         FileUrl(name="two", url="two.md"),
     }
+
+
+def test_newlines_are_added_to_stdout():
+    yaml_str = """
+- unit: "Statement and main"
+  cases:
+  - script:
+      - arguments: [ '-a', '5', '7' ]
+        stdout:
+          data: 12
+          config:
+            tryFloatingPoint: true
+        """
+    json_str = translate_to_test_suite(yaml_str)
+    suite = parse_test_suite(json_str)
+    actual_stdout = suite.tabs[0].contexts[0].testcases[0].output.stdout.data
+    assert actual_stdout == "12\n"
+
+    yaml_str2 = """
+- unit: "Statement and main"
+  cases:
+  - script:
+      - arguments: [ '-a', '5', '7' ]
+        stdout: "hello"
+        """
+    json_str = translate_to_test_suite(yaml_str2)
+    suite = parse_test_suite(json_str)
+    actual_stdout = suite.tabs[0].contexts[0].testcases[0].output.stdout.data
+    assert actual_stdout == "hello\n"
+
+
+def test_newlines_are_added_to_stderr():
+    yaml_str = """
+- unit: "Statement and main"
+  cases:
+  - script:
+      - arguments: [ '-a', '5', '7' ]
+        stderr:
+          data: 12
+          config:
+            tryFloatingPoint: true
+        """
+    json_str = translate_to_test_suite(yaml_str)
+    suite = parse_test_suite(json_str)
+    actual_stderr = suite.tabs[0].contexts[0].testcases[0].output.stderr.data
+    assert actual_stderr == "12\n"
+
+    yaml_str2 = """
+- unit: "Statement and main"
+  cases:
+  - script:
+      - arguments: [ '-a', '5', '7' ]
+        stderr: "hello"
+        """
+    json_str = translate_to_test_suite(yaml_str2)
+    suite = parse_test_suite(json_str)
+    actual_stderr = suite.tabs[0].contexts[0].testcases[0].output.stderr.data
+    assert actual_stderr == "hello\n"
+
+
+def test_no_duplicate_newlines_are_added():
+    yaml_str = """
+- unit: "Statement and main"
+  cases:
+  - script:
+      - arguments: [ '-a', '5', '7' ]
+        stdout: |
+            hello
+            world
+        """
+    json_str = translate_to_test_suite(yaml_str)
+    suite = parse_test_suite(json_str)
+    actual = suite.tabs[0].contexts[0].testcases[0].output.stdout.data
+    assert actual == "hello\nworld\n"
+
+
+def test_can_disable_normalizing_newlines():
+    yaml_str = """
+- unit: "Statement and main"
+  cases:
+  - script:
+      - arguments: [ '-a', '5', '7' ]
+        stderr:
+          data: 12
+          config:
+            tryFloatingPoint: true
+            normalizeTrailingNewlines: false
+        """
+    json_str = translate_to_test_suite(yaml_str)
+    suite = parse_test_suite(json_str)
+    actual_stderr = suite.tabs[0].contexts[0].testcases[0].output.stderr.data
+    assert actual_stderr == "12"

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -251,7 +251,7 @@ def test_file_oracle_dont_strip_lines_correct(tmp_path: Path, pytestconfig, mock
     s = mocker.spy(tested.oracles.text, name="compare_text")
     mock_files = [
         mocker.mock_open(read_data=content).return_value
-        for content in ["expected\nexpected2\n", "expected\nexpected2"]
+        for content in ["expected\nexpected2\n", "expected\nexpected2\n"]
     ]
     mock_opener = mocker.mock_open()
     mock_opener.side_effect = mock_files
@@ -261,11 +261,11 @@ def test_file_oracle_dont_strip_lines_correct(tmp_path: Path, pytestconfig, mock
     )
     result = evaluate_file(config, channel, "")
     s.assert_any_call(ANY, "expected\n", "expected\n")
-    s.assert_any_call(ANY, "expected2\n", "expected2")
+    s.assert_any_call(ANY, "expected2\n", "expected2\n")
     assert s.call_count == 2
     assert result.result.enum == Status.CORRECT
     assert result.readable_expected == "expected\nexpected2\n"
-    assert result.readable_actual == "expected\nexpected2"
+    assert result.readable_actual == "expected\nexpected2\n"
 
 
 def test_exception_oracle_only_messages_correct(tmp_path: Path, pytestconfig):


### PR DESCRIPTION
- Text is now checked strictly be default: there must be an exact match.
   - The option `ignoreWhitespace` is still present and can be used to revert to the current behaviour if needed.
- By default, we ensure that the expected values for stdout/stderr in the DSL end with a newline.
   - We only add a newline if there is none.
   - This can be disabled by setting `normalizeTrailingNewlines` to false.
   - We also apply this when using custom oracles.
- We don't do this for JSON test suites, so those should be updated (but apart from a few non-used exercises from us, no one uses the JSON test suites, so I don't think this is a problem).

Fixes #462. 