### PR TITLE
Minor fixes+additions to CLI + fixes to custom_check oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The second way is:
 ```bash
 # Run an exercise with CLI paramaters
 $ python -m tested.cli --help
-usage: cli.py [-h] -e EXERCISE [-s SUBMISSION] [-t TESTSUITE] [-f] [-p PROGRAMMING_LANGUAGE]
+usage: cli.py [-h] -e EXERCISE [-s SUBMISSION] [-t TESTSUITE] [-f] [-v] [-d] [-p PROGRAMMING_LANGUAGE]
 
 Simple CLI for TESTed
 
@@ -202,6 +202,8 @@ options:
   -t TESTSUITE, --testsuite TESTSUITE
                         Path to a test suite
   -f, --full            If the output should be shown in full (default: false)
+  -v, --verbose         If the judge should be verbose in its output (default: false)
+  -d, --debug           If the judge should be outputing the debug messages (default: false)
   -p PROGRAMMING_LANGUAGE, --programming_language PROGRAMMING_LANGUAGE
                         The programming language to use
 

--- a/tested/cli.py
+++ b/tested/cli.py
@@ -135,19 +135,19 @@ if __name__ == "__main__":
         "-f",
         "--full",
         action="store_true",
-        help="If the output should be shown in full (default: false)"
+        help="If the output should be shown in full (default: false)",
     )
     parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
-        help="If the judge should be verbose in its output (default: false)"
+        help="If the judge should be verbose in its output (default: false)",
     )
     parser.add_argument(
         "-d",
         "--debug",
         action="store_true",
-        help="If the judge should be outputing the debug messages (default: false)"
+        help="If the judge should be outputing the debug messages (default: false)",
     )
     parser.add_argument(
         "-p",
@@ -207,7 +207,9 @@ if __name__ == "__main__":
     workdir_path = judge_path / "workdir"
 
     if args.verbose or args.debug:
-        import logging, sys
+        import logging
+        import sys
+
         logger = logging.getLogger()
         if args.debug:
             logger.setLevel(logging.DEBUG)

--- a/tested/cli.py
+++ b/tested/cli.py
@@ -134,9 +134,20 @@ if __name__ == "__main__":
     parser.add_argument(
         "-f",
         "--full",
-        action="store_false",
-        help="If the output should be shown in full (default: false)",
-        default=None,
+        action="store_true",
+        help="If the output should be shown in full (default: false)"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="If the judge should be verbose in its output (default: false)"
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="If the judge should be outputing the debug messages (default: false)"
     )
     parser.add_argument(
         "-p",
@@ -177,21 +188,35 @@ if __name__ == "__main__":
         suite_path = args.testsuite.relative_to(evaluation_path)
     elif "evaluation" in config_file and "test_suite" in config_file["evaluation"]:
         # The config file contains a location, so try to use it.
-        suite_path = evaluation_path / config_file["evaluation"]["test_suite"]
-        if not suite_path.is_file():
+        suite_path = config_file["evaluation"]["test_suite"]
+        suite_full_path = evaluation_path / suite_path
+        if not suite_full_path.is_file():
             raise FileNotFoundError(
-                f"The test suite at {suite_path} does not exist (read value from the config file).\n"
-                "Create the file, correct the config.json file or provide the path to the test suite via the --testsuite parameter on the command line."
+                f"The test suite at {suite_full_path} does not exist (read value {suite_path} from the config file).\n"
+                "Create the file, correct the config.json file or provide the full path to the test suite via the --testsuite parameter on the command line."
             )
     else:
-        suite_path = evaluation_path / "suite.yaml"
-        if not suite_path.is_file():
+        suite_path = "suite.yaml"
+        suite_full_path = evaluation_path / suite_path
+        if not suite_full_path.is_file():
             raise FileNotFoundError(
-                f"The test suite at {suite_path} does not exist (used default value).\n"
-                "Create the file, add the location to the config.json file or provide the path to the test suite via the --testsuite parameter on the command line."
+                f"The test suite at {suite_full_path} does not exist (used default value).\n"
+                "Create the file, add the location to the config.json file or provide the full path to the test suite via the --testsuite parameter on the command line."
             )
     submission_path = find_submission()
     workdir_path = judge_path / "workdir"
+
+    if args.verbose or args.debug:
+        import logging, sys
+        logger = logging.getLogger()
+        if args.debug:
+            logger.setLevel(logging.DEBUG)
+        elif args.verbose:
+            logger.setLevel(logging.INFO)
+        ch = logging.StreamHandler(stream=sys.stdout)
+        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
 
     dodona_config = DodonaConfig(
         resources=evaluation_path,
@@ -211,7 +236,7 @@ if __name__ == "__main__":
 
     print(f"Locally executing exercise {exercise_path}...")
     print("The following options will be used:")
-    print(f" - Test suite: {suite_path}")
+    print(f" - Test suite: {evaluation_path}/{suite_path}")
     print(f" - Submission: {submission_path}")
     print("")
     print(


### PR DESCRIPTION
This pull request Fixes some minor issues with the CLI interface as well as adds the new options to have it output verbosely or even at a debug level.
Additionally the changes in the pull request came from the need to use a custom oracle which did not seem to work at all as how the docs described it. As a result I have fixed the classes defined in the documentation (and the one also not there) now properly being available in the scope of the custom oracle function so they can be used to nicely return a result and messages.

Additional to this pull request there is a pull request [dodona-edu/dodona-edu.github.io #396](https://github.com/dodona-edu/dodona-edu.github.io/pull/396) to fix the documentation on this subject as the examples and explanation for creating a custom oracle are wrong or at best very confusing, so I would also appreciate it if that also got reviewed so nobody else needs to lose as much time to this as I did.


Changes to tested.cli:
- Fixed the -f/--full options actually disabling the full output rather than enabling as its documentation explains
- Added a -v/--verbose and -d/--debug options that change the logger to add output info/debug level messages to the standard output stream, analogous to tested module itself enables these. Additionally if both are selected debug is used as it is a higher level than info
- Fied the suite path not properly being passed to the DodonaConfig, as the config expects it relative to the resources path

Changes to tested.oracles.programmed
- Fixed the Message, EvaluationResult, and ConvertedOracleContext not being available when running a custom oracle by providing them as a type alias rather than trying to simply add the module to sys.modules, which does not seem to actually make it avialable to the custom oracle function