### PR TITLE
Do not add newlines to empty strings

### DIFF
--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -91,7 +91,7 @@ YamlObject = (
 
 
 def _ensure_trailing_newline(text: str) -> str:
-    if not text.endswith("\n"):
+    if text and not text.endswith("\n"):
         return text + "\n"
     else:
         return text

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -1099,4 +1099,4 @@ def test_empty_text_data_newlines():
     json_str = translate_to_test_suite(yaml_str)
     suite = parse_test_suite(json_str)
     actual_stderr = suite.tabs[0].contexts[0].testcases[0].output.stderr.data
-    assert actual_stderr == "\n"
+    assert actual_stderr == ""


### PR DESCRIPTION
When updating the documentation, it occurred to me that we currently also append newlines to empty strings for stdout/stderr. This is probably not what we want (since an empty stdout/stderr is perfectly fine), and also not how POSIX defines a file (zero or more lines).