### PR TITLE
Improve JavaScript handling of Map/Object

### DIFF
--- a/tested/datatypes/__init__.py
+++ b/tested/datatypes/__init__.py
@@ -16,6 +16,7 @@ They are also split in "basic types" and "advanced types".
 from tested.datatypes.advanced import (
     AdvancedNothingTypes,
     AdvancedNumericTypes,
+    AdvancedObjectTypes,
     AdvancedSequenceTypes,
     AdvancedStringTypes,
     AdvancedTypes,
@@ -37,7 +38,7 @@ StringTypes = BasicStringTypes | AdvancedStringTypes
 BooleanTypes = BasicBooleanTypes
 NothingTypes = BasicNothingTypes | AdvancedNothingTypes
 SequenceTypes = BasicSequenceTypes | AdvancedSequenceTypes
-ObjectTypes = BasicObjectTypes
+ObjectTypes = BasicObjectTypes | AdvancedObjectTypes
 
 SimpleTypes = NumericTypes | StringTypes | BooleanTypes | NothingTypes
 ComplexTypes = SequenceTypes | ObjectTypes

--- a/tested/datatypes/advanced.py
+++ b/tested/datatypes/advanced.py
@@ -11,6 +11,7 @@ from typing import Union
 from tested.datatypes.basic import (
     BasicNothingTypes,
     BasicNumericTypes,
+    BasicObjectTypes,
     BasicSequenceTypes,
     BasicStringTypes,
     BasicTypes,
@@ -111,9 +112,21 @@ class AdvancedNothingTypes(_AdvancedDataType):
     """
 
 
+class AdvancedObjectTypes(_AdvancedDataType):
+    DICTIONARY = "dictionary", BasicObjectTypes.MAP
+    """
+    A proper map/dictionary/associative array data structure.
+    """
+    OBJECT = "object", BasicObjectTypes.MAP
+    """
+    An object like in JavaScript.
+    """
+
+
 AdvancedTypes = Union[
     AdvancedNumericTypes,
     AdvancedSequenceTypes,
     AdvancedStringTypes,
     AdvancedNothingTypes,
+    AdvancedObjectTypes,
 ]

--- a/tested/features.py
+++ b/tested/features.py
@@ -224,6 +224,10 @@ def is_supported(language: "Language") -> list[Message] | None:
             key, collection_restrictions.get(basic_key)
         )
 
+        # If None, skip as there are no restrictions.
+        if restrictions is None:
+            continue
+
         # Types that have reduced support are converted, so we also need to
         # convert them here in the checks.
         basic_value_types = set()
@@ -233,7 +237,7 @@ def is_supported(language: "Language") -> list[Message] | None:
             else:
                 basic_value_types.add(value_type)
 
-        if not (basic_value_types <= restricted[key]):  # type: ignore
+        if not (basic_value_types <= restrictions):  # type: ignore
             _logger.warning("This test suite is not compatible!")
             _logger.warning(
                 f"Required {key} types are {value_types} (or {basic_value_types})."

--- a/tested/languages/config.py
+++ b/tested/languages/config.py
@@ -244,29 +244,24 @@ class Language(ABC):
         """
         return set()
 
-    def map_type_restrictions(self) -> set[ExpressionTypes] | None:
+    def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
         """
-        Get type restrictions that apply to map types in this language.
+        Get type restrictions for other types.
 
-        If you return None, all data types are assumed to be usable as the key in
-        a map data type, such as a dictionary or hashmap. Otherwise, you must return
-        a whitelist of the allowed types.
+        The exact interpretation varies by the type. Only some restrictions are
+        currently recognized:
 
-        :return: The whitelist of allowed types, or everything is allowed.
+        Restrictions on `BasicObjectTypes.Map` (or related advanced types) are
+        interpreted as restrictions on the type of the keys. The provided types
+        are a whitelist: the only allowed types.
+
+        Restrictions on `BasicSetTypes.SET` (or related advanced types) are
+        interpreted as restrictions on the type of the elements. The provided
+        types are a whitelist: the only allowed types.
+
+        :return: Mapping of types to their restrictions. Unmapped types are unrestricted.
         """
-        return None
-
-    def set_type_restrictions(self) -> set[ExpressionTypes] | None:
-        """
-        Get type restrictions that apply to the set types in this language.
-
-        If you return None, all data types are assumed to be usable as the key in
-        a set data type, such as a HashSet. Otherwise, you must return a whitelist
-        of the allowed types.
-
-        :return: The whitelist of allowed types, or everything is allowed.
-        """
-        return None
+        return dict()
 
     def datatype_support(self) -> dict[AllTypes, TypeSupport]:
         """

--- a/tested/languages/csharp/config.py
+++ b/tested/languages/csharp/config.py
@@ -76,6 +76,8 @@ class CSharp(Language):
             "sequence": "supported",
             "set": "supported",
             "map": "supported",
+            "dictionary": "supported",
+            "object": "reduced",
             "nothing": "supported",
             "undefined": "reduced",
             "null": "reduced",

--- a/tested/languages/csharp/templates/Values.cs
+++ b/tested/languages/csharp/templates/Values.cs
@@ -88,7 +88,7 @@ namespace Tested
                 type = "set";
                 data = encodeSequence((IEnumerable) value);
             } else if (value is IDictionary) {
-                type = "map";
+                type = "dictionary";
                 List<DictionaryEntry> entries = new List<DictionaryEntry>();
                 foreach (DictionaryEntry entry in (IDictionary) value)
                 {

--- a/tested/languages/java/config.py
+++ b/tested/languages/java/config.py
@@ -74,6 +74,7 @@ class Java(Language):
             "text": "supported",
             "boolean": "supported",
             "sequence": "supported",
+            "tuple": "reduced",
             "set": "supported",
             "map": "supported",
             "dictionary": "supported",

--- a/tested/languages/java/config.py
+++ b/tested/languages/java/config.py
@@ -3,7 +3,12 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tested.datatypes import AllTypes, ExpressionTypes
+from tested.datatypes import (
+    AllTypes,
+    BasicObjectTypes,
+    BasicSequenceTypes,
+    ExpressionTypes,
+)
 from tested.dodona import AnnotateCode, Message
 from tested.features import Construct, TypeSupport
 from tested.languages.config import (
@@ -71,6 +76,8 @@ class Java(Language):
             "sequence": "supported",
             "set": "supported",
             "map": "supported",
+            "dictionary": "supported",
+            "object": "reduced",
             "nothing": "supported",
             "undefined": "reduced",
             "null": "reduced",
@@ -91,8 +98,8 @@ class Java(Language):
             "list": "supported",
         }
 
-    def map_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return {  # type: ignore
+    def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
+        restrictions = {
             "integer",
             "real",
             "char",
@@ -113,9 +120,10 @@ class Java(Language):
             "function_calls",
             "identifiers",
         }
-
-    def set_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return self.map_type_restrictions()
+        return {
+            BasicObjectTypes.MAP: restrictions,  # type: ignore
+            BasicSequenceTypes.SET: restrictions,
+        }
 
     def compilation(self, files: list[str]) -> CallbackResult:
         def file_filter(file: Path) -> bool:
@@ -171,6 +179,8 @@ class Java(Language):
                 "sequence": "List",
                 "set": "Set",
                 "map": "Map",
+                "dictionary": "Map",
+                "object": "Map",
                 "nothing": "Void",
                 "undefined": "Void",
                 "int8": "byte",

--- a/tested/languages/java/templates/Values.java
+++ b/tested/languages/java/templates/Values.java
@@ -112,7 +112,7 @@ public class Values {
             type = "set";
             data = encodeSequence((Iterable<?>) value);
         } else if (value instanceof Map) {
-            type = "map";
+            type = "dictionary";
             var elements = new ArrayList<String>();
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
                 elements.add("{ \"key\":" + encode(entry.getKey()) + ",\"value\": " + encode(entry.getValue()) + "}");
@@ -163,7 +163,7 @@ public class Values {
         var description = asJson(message.description);
         var format = asJson(message.format);
         var permission = asJson(message.permission);
-        
+
         return """
                 {
                   "description": %s,
@@ -172,7 +172,7 @@ public class Values {
                 }
                 """.formatted(description, format, permission);
     }
-    
+
     private static String asJson(String value) {
         if (value == null) {
             return "null";
@@ -188,7 +188,7 @@ public class Values {
         var dslExpected = asJson(r.dslExpected);
         var dslActual = asJson(r.dslActual);
         var messages = String.join(", ", converted);
-        
+
         String result = """
                 {
                   "result": %b,

--- a/tested/languages/javascript/config.py
+++ b/tested/languages/javascript/config.py
@@ -3,7 +3,12 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tested.datatypes import AllTypes, BasicStringTypes, ExpressionTypes
+from tested.datatypes import (
+    AdvancedObjectTypes,
+    AllTypes,
+    BasicStringTypes,
+    ExpressionTypes,
+)
 from tested.dodona import AnnotateCode, Message
 from tested.features import Construct, TypeSupport
 from tested.languages.config import (
@@ -72,6 +77,8 @@ class JavaScript(Language):
             "sequence": "supported",
             "set": "supported",
             "map": "supported",
+            "dictionary": "supported",
+            "object": "supported",
             "nothing": "supported",
             "undefined": "supported",
             "null": "supported",
@@ -92,21 +99,8 @@ class JavaScript(Language):
             "tuple": "reduced",
         }
 
-    def map_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return {BasicStringTypes.TEXT}
-
-    def set_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return {  # type: ignore
-            "integer",
-            "real",
-            "text",
-            "boolean",
-            "sequence",
-            "set",
-            "map",
-            "function_calls",
-            "identifiers",
-        }
+    def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
+        return {AdvancedObjectTypes.OBJECT: {BasicStringTypes.TEXT}}
 
     def compilation(self, files: list[str]) -> CallbackResult:
         submission = submission_file(self)

--- a/tested/languages/javascript/config.py
+++ b/tested/languages/javascript/config.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 from tested.datatypes import (
     AdvancedObjectTypes,
     AllTypes,
-    BasicNumericTypes,
-    BasicSequenceTypes,
     BasicStringTypes,
     ExpressionTypes,
 )
@@ -102,13 +100,7 @@ class JavaScript(Language):
         }
 
     def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
-        return {
-            AdvancedObjectTypes.OBJECT: {BasicStringTypes.TEXT},
-            BasicSequenceTypes.SET: {
-                BasicSequenceTypes.SEQUENCE,
-                BasicNumericTypes.INTEGER,
-            },
-        }
+        return {AdvancedObjectTypes.OBJECT: {BasicStringTypes.TEXT}}
 
     def compilation(self, files: list[str]) -> CallbackResult:
         submission = submission_file(self)

--- a/tested/languages/javascript/config.py
+++ b/tested/languages/javascript/config.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from tested.datatypes import (
     AdvancedObjectTypes,
     AllTypes,
+    BasicNumericTypes,
+    BasicSequenceTypes,
     BasicStringTypes,
     ExpressionTypes,
 )
@@ -100,7 +102,13 @@ class JavaScript(Language):
         }
 
     def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
-        return {AdvancedObjectTypes.OBJECT: {BasicStringTypes.TEXT}}
+        return {
+            AdvancedObjectTypes.OBJECT: {BasicStringTypes.TEXT},
+            BasicSequenceTypes.SET: {
+                BasicSequenceTypes.SEQUENCE,
+                BasicNumericTypes.INTEGER,
+            },
+        }
 
     def compilation(self, files: list[str]) -> CallbackResult:
         submission = submission_file(self)

--- a/tested/languages/javascript/generators.py
+++ b/tested/languages/javascript/generators.py
@@ -11,6 +11,7 @@ from tested.datatypes import (
     BasicSequenceTypes,
     BasicStringTypes,
 )
+from tested.datatypes.advanced import AdvancedObjectTypes
 from tested.languages.conventionalize import submission_file
 from tested.languages.preparation import (
     PreparedContext,
@@ -48,6 +49,17 @@ def convert_value(value: Value) -> str:
         raise AssertionError("Double extended values are not supported in js.")
     elif value.type == AdvancedNumericTypes.FIXED_PRECISION:
         raise AssertionError("Fixed precision values are not supported in js.")
+    elif value.type == AdvancedObjectTypes.OBJECT:
+        assert isinstance(value, ObjectType)
+        result = "{"
+        for i, pair in enumerate(value.data):
+            result += convert_statement(pair.key, True)
+            result += ": "
+            result += convert_statement(pair.value, True)
+            if i != len(value.data) - 1:
+                result += ", "
+        result += "}"
+        return result
     elif value.type in (
         AdvancedNumericTypes.INT_64,
         AdvancedNumericTypes.U_INT_64,
@@ -79,14 +91,16 @@ def convert_value(value: Value) -> str:
         return f"new Set([{convert_arguments(value.data)}])"
     elif value.type == BasicObjectTypes.MAP:
         assert isinstance(value, ObjectType)
-        result = "{"
+        result = "new Map(["
         for i, pair in enumerate(value.data):
+            result += "["
             result += convert_statement(pair.key, True)
-            result += ": "
+            result += ", "
             result += convert_statement(pair.value, True)
+            result += "]"
             if i != len(value.data) - 1:
                 result += ", "
-        result += "}"
+        result += "])"
         return result
     elif value.type == BasicStringTypes.UNKNOWN:
         assert isinstance(value, StringType)

--- a/tested/languages/javascript/templates/values.js
+++ b/tested/languages/javascript/templates/values.js
@@ -53,7 +53,7 @@ function encode(value) {
             type = "set";
             value = Array.from(value).map(encode);
         } else if (value instanceof Map) {
-            type = "map";
+            type = "dictionary";
             value = Array
                     .from(value)
                     .map(([key, value]) => {
@@ -65,7 +65,7 @@ function encode(value) {
                     );
         } else if (value?.constructor === Object) {
             // Plain objects
-            type = "map";
+            type = "object";
             // Process the elements of the object.
             value = Object.entries(value).map(([key, value]) => {
                 return {

--- a/tested/languages/kotlin/config.py
+++ b/tested/languages/kotlin/config.py
@@ -4,7 +4,12 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tested.datatypes import AllTypes, ExpressionTypes
+from tested.datatypes import (
+    AllTypes,
+    BasicObjectTypes,
+    BasicSequenceTypes,
+    ExpressionTypes,
+)
 from tested.dodona import AnnotateCode, Message, Status
 from tested.features import Construct, TypeSupport
 from tested.languages.config import (
@@ -80,6 +85,8 @@ class Kotlin(Language):
             "sequence": "supported",
             "set": "supported",
             "map": "supported",
+            "dictionary": "supported",
+            "object": "reduced",
             "nothing": "supported",
             "undefined": "reduced",
             "null": "reduced",
@@ -101,8 +108,8 @@ class Kotlin(Language):
             "tuple": "reduced",
         }
 
-    def map_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return {  # type: ignore
+    def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
+        restrictions = {
             "integer",
             "real",
             "char",
@@ -124,9 +131,10 @@ class Kotlin(Language):
             "function_calls",
             "identifiers",
         }
-
-    def set_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return self.map_type_restrictions()
+        return {
+            BasicObjectTypes.MAP: restrictions,  # type: ignore
+            BasicSequenceTypes.SET: restrictions,  # type: ignore
+        }
 
     def compilation(self, files: list[str]) -> CallbackResult:
         def file_filter(file: Path) -> bool:

--- a/tested/languages/kotlin/templates/Values.kt
+++ b/tested/languages/kotlin/templates/Values.kt
@@ -124,7 +124,7 @@ private fun internalEncode(value: Any?): Array<String?> {
         type = "set"
         data = encodeSequence(value.asIterable())
     } else if (value is Map<*, *>) {
-        type = "map"
+        type = "dictionary"
         data = value.asSequence()
                 .map { e ->
                     String.format("{\"key\": %s, \"value\": %s }", encode(e.key),

--- a/tested/languages/python/config.py
+++ b/tested/languages/python/config.py
@@ -4,7 +4,12 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tested.datatypes import AllTypes, ExpressionTypes
+from tested.datatypes import (
+    AllTypes,
+    BasicObjectTypes,
+    BasicSequenceTypes,
+    ExpressionTypes,
+)
 from tested.dodona import AnnotateCode, Message, Severity
 from tested.features import Construct, TypeSupport
 from tested.languages.config import (
@@ -77,6 +82,8 @@ class Python(Language):
             "sequence": "supported",
             "set": "supported",
             "map": "supported",
+            "dictionary": "supported",
+            "object": "reduced",
             "nothing": "supported",
             "undefined": "reduced",
             "null": "reduced",
@@ -98,8 +105,8 @@ class Python(Language):
             "tuple": "supported",
         }
 
-    def map_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return {  # type: ignore
+    def collection_restrictions(self) -> dict[AllTypes, set[ExpressionTypes]]:
+        restrictions = {
             "integer",
             "real",
             "text",
@@ -110,9 +117,10 @@ class Python(Language):
             "function_calls",
             "identifiers",
         }
-
-    def set_type_restrictions(self) -> set[ExpressionTypes] | None:
-        return self.map_type_restrictions()
+        return {
+            BasicObjectTypes.MAP: restrictions,  # type: ignore
+            BasicSequenceTypes.SET: restrictions,  # type: ignore
+        }
 
     def compilation(self, files: list[str]) -> CallbackResult:
         result = [x.replace(".py", ".pyc") for x in files]

--- a/tested/languages/python/templates/values.py
+++ b/tested/languages/python/templates/values.py
@@ -52,7 +52,7 @@ def encode(value):
         type_ = "set"
         data_ = [encode(x) for x in value]
     elif isinstance(value, dict):
-        type_ = "map"
+        type_ = "dictionary"
         data_ = [{"key": encode(k), "value": encode(v)} for k, v in value.items()]
     else:
         type_ = "unknown"

--- a/tests/exercises/objects/evaluation/advanced_values_in_set.yaml
+++ b/tests/exercises/objects/evaluation/advanced_values_in_set.yaml
@@ -1,0 +1,6 @@
+namespace: "EqualChecker"
+tabs:
+- tab: "Feedback"
+  testcases:
+    - expression: 'set_test()'
+      return: !expression "{(1, 2), (2, 3)}"

--- a/tests/exercises/objects/evaluation/missing_key_types_js_dictionary.yaml
+++ b/tests/exercises/objects/evaluation/missing_key_types_js_dictionary.yaml
@@ -1,0 +1,4 @@
+- tab: "Feedback"
+  testcases:
+    - expression: 'dictionary({5: "a"})'
+      return: {5: "a"}

--- a/tests/exercises/objects/evaluation/missing_key_types_js_object.yaml
+++ b/tests/exercises/objects/evaluation/missing_key_types_js_object.yaml
@@ -1,0 +1,4 @@
+- tab: "Feedback"
+  testcases:
+    - expression: 'object({5: "a"})'
+      return: "invalid"

--- a/tests/exercises/objects/solution/correct.java
+++ b/tests/exercises/objects/solution/correct.java
@@ -1,3 +1,5 @@
+import java.util.*;
+
 class EqualChecker {
 
     private final int number;
@@ -8,5 +10,9 @@ class EqualChecker {
 
     public boolean check(int other) {
         return this.number == other;
+    }
+
+    public static Set<List<Integer>> setTest() {
+        return Set.of(List.of(1, 2), List.of(2, 3));
     }
 }

--- a/tests/exercises/objects/solution/correct.js
+++ b/tests/exercises/objects/solution/correct.js
@@ -7,3 +7,7 @@ class EqualChecker {
         return other === this.number;
     }
 }
+
+function setTest() {
+    return new Set([[1, 2], [2, 3]]);
+}

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -5,11 +5,13 @@ import pytest
 from tested.datatypes import (
     AdvancedNothingTypes,
     AdvancedNumericTypes,
+    AdvancedObjectTypes,
     AdvancedSequenceTypes,
     AdvancedStringTypes,
     BasicBooleanTypes,
     BasicNothingTypes,
     BasicNumericTypes,
+    BasicObjectTypes,
     BasicSequenceTypes,
     BasicStringTypes,
     ObjectTypes,
@@ -229,7 +231,49 @@ def test_parse_value_adv_sequence():
 
 def test_parse_value_dict():
     parsed = parse_string('{"ignore": True, 5: 0}')
-    assert parsed.type == ObjectTypes.MAP
+    assert parsed.type == BasicObjectTypes.MAP
+    parsed: ObjectType
+    assert len(parsed.data) == 2
+    key, value = parsed.data[0].key, parsed.data[0].value
+    assert isinstance(key, StringType)
+    assert key.type == BasicStringTypes.TEXT
+    assert key.data == "ignore"
+    assert isinstance(value, BooleanType)
+    assert value.type == BasicBooleanTypes.BOOLEAN
+    assert value.data is True
+    key, value = parsed.data[1].key, parsed.data[1].value
+    assert isinstance(key, NumberType)
+    assert key.type == BasicNumericTypes.INTEGER
+    assert key.data == 5
+    assert isinstance(value, NumberType)
+    assert value.type == BasicNumericTypes.INTEGER
+    assert value.data == 0
+
+
+def test_parse_value_dictionary():
+    parsed = parse_string('dictionary({"ignore": True, 5: 0})')
+    assert parsed.type == AdvancedObjectTypes.DICTIONARY
+    parsed: ObjectType
+    assert len(parsed.data) == 2
+    key, value = parsed.data[0].key, parsed.data[0].value
+    assert isinstance(key, StringType)
+    assert key.type == BasicStringTypes.TEXT
+    assert key.data == "ignore"
+    assert isinstance(value, BooleanType)
+    assert value.type == BasicBooleanTypes.BOOLEAN
+    assert value.data is True
+    key, value = parsed.data[1].key, parsed.data[1].value
+    assert isinstance(key, NumberType)
+    assert key.type == BasicNumericTypes.INTEGER
+    assert key.data == 5
+    assert isinstance(value, NumberType)
+    assert value.type == BasicNumericTypes.INTEGER
+    assert value.data == 0
+
+
+def test_parse_value_object():
+    parsed = parse_string('object({"ignore": True, 5: 0})')
+    assert parsed.type == AdvancedObjectTypes.OBJECT
     parsed: ObjectType
     assert len(parsed.data) == 2
     key, value = parsed.data[0].key, parsed.data[0].value
@@ -375,7 +419,7 @@ def test_parse_function():
     assert function.name == "generate"
     assert len(function.arguments) == 1
     arg = function.arguments[0]
-    assert arg.type == ObjectTypes.MAP
+    assert arg.type == BasicObjectTypes.MAP
     arg: ObjectType
     assert len(arg.data) == 1
     pair: ObjectKeyValuePair = arg.data[0]

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -552,6 +552,22 @@ def test_missing_key_types_detected_js_dictionary(
     assert updates.find_status_enum() == ["correct"]
 
 
+@pytest.mark.parametrize("lang", ["java"])
+def test_advanced_types_are_allowed(lang: str, tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "objects",
+        lang,
+        tmp_path,
+        "advanced_values_in_set.yaml",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("start-testcase")) == 1
+    assert updates.find_status_enum() == ["correct"]
+
+
 @pytest.mark.parametrize("lang", ["python", "java", "kotlin", "javascript", "csharp"])
 def test_programmed_evaluator_lotto(lang: str, tmp_path: Path, pytestconfig):
     conf = configuration(

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -512,15 +512,44 @@ def test_heterogeneous_arguments_are_detected(lang: str, tmp_path: Path, pytestc
     assert updates.find_status_enum() == ["internal error"]
 
 
-@pytest.mark.parametrize("lang", ["python", "javascript"])
-def test_missing_key_types_detected(lang: str, tmp_path: Path, pytestconfig):
+def test_missing_key_types_detected(tmp_path: Path, pytestconfig):
     conf = configuration(
-        pytestconfig, "objects", lang, tmp_path, "missing_key_types.yaml", "solution"
+        pytestconfig, "objects", "python", tmp_path, "missing_key_types.yaml", "correct"
     )
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
     assert len(updates.find_all("start-testcase")) == 0
     assert updates.find_status_enum() == ["internal error"]
+
+
+def test_missing_key_types_detected_js_object(tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "objects",
+        "javascript",
+        tmp_path,
+        "missing_key_types_js_object.yaml",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("start-testcase")) == 0
+    assert updates.find_status_enum() == ["internal error"]
+
+
+@pytest.mark.parametrize(
+    "suite", ["missing_key_types_js_dictionary", "missing_key_types"]
+)
+def test_missing_key_types_detected_js_dictionary(
+    suite: str, tmp_path: Path, pytestconfig
+):
+    conf = configuration(
+        pytestconfig, "objects", "javascript", tmp_path, f"{suite}.yaml", "correct"
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("start-testcase")) == 1
+    assert updates.find_status_enum() == ["correct"]
 
 
 @pytest.mark.parametrize("lang", ["python", "java", "kotlin", "javascript", "csharp"])

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -33,6 +33,7 @@ from tested.datatypes import (
     BasicTypes,
     resolve_to_basic,
 )
+from tested.datatypes.advanced import AdvancedObjectTypes
 from tested.features import TypeSupport, fallback_type_support_map
 from tested.judge.compilation import run_compilation
 from tested.judge.execution import execute_file, filter_files
@@ -161,9 +162,26 @@ ADVANCED_VALUES = [
             StringType(type=BasicStringTypes.TEXT, data="data"),
         ],
     ),
-    # Char
     StringType(type=AdvancedStringTypes.CHAR, data="h"),
     NothingType(type=AdvancedNothingTypes.UNDEFINED),
+    ObjectType(
+        type=AdvancedObjectTypes.DICTIONARY,
+        data=[
+            ObjectKeyValuePair(
+                key=StringType(type=BasicStringTypes.TEXT, data="data"),
+                value=NumberType(type=BasicNumericTypes.INTEGER, data=5),
+            )
+        ],
+    ),
+    ObjectType(
+        type=AdvancedObjectTypes.OBJECT,
+        data=[
+            ObjectKeyValuePair(
+                key=StringType(type=BasicStringTypes.TEXT, data="data"),
+                value=NumberType(type=BasicNumericTypes.INTEGER, data=5),
+            )
+        ],
+    ),
 ]
 
 


### PR DESCRIPTION
Switch to Map by default and introduce two new advanced types to make the distinction between Map/Object when needed. The new types are `dictionary` (since `map` is already in use) for the data structure and `object` for the JavaScript-specific `Object` type, which no other language natively supports at the moment.

All existing languages have been updated to support the `dictionary` advanced type if they supported the basic `map` type, while the advanced type for `object` is reduced, except in JavaScript, which supports both.

As part of this, the way to indicate type limits on certain elements of collections has been reworked to be more flexible. It is now possible to specify limits for all types separately. At the moment, we still only recognise limits on map keys and set elements, so nothing changes there.

Fixes #386