### PR TITLE
Add support for property/attribute assignment

### DIFF
--- a/tested/languages/bash/generators.py
+++ b/tested/languages/bash/generators.py
@@ -11,13 +11,13 @@ from tested.languages.preparation import (
 )
 from tested.languages.utils import convert_unknown_type
 from tested.serialisation import (
-    Assignment,
     FunctionCall,
     FunctionType,
     Identifier,
     Statement,
     StringType,
     Value,
+    VariableAssignment,
 )
 from tested.testsuite import MainInput
 
@@ -153,7 +153,7 @@ def convert_statement(statement: Statement) -> str:
         return convert_function_call(statement, index_fun, [])
     elif isinstance(statement, Value):
         return convert_value(statement)
-    elif isinstance(statement, Assignment):
+    elif isinstance(statement, VariableAssignment):
         result = f"local {statement.variable}="
         if isinstance(statement.expression, FunctionCall):
             result += f"$({convert_statement(statement.expression)})"

--- a/tested/languages/c/generators.py
+++ b/tested/languages/c/generators.py
@@ -19,7 +19,6 @@ from tested.languages.preparation import (
 )
 from tested.languages.utils import convert_unknown_type, is_special_void_call
 from tested.serialisation import (
-    Assignment,
     Expression,
     FunctionCall,
     FunctionType,
@@ -29,6 +28,7 @@ from tested.serialisation import (
     Statement,
     StringType,
     Value,
+    VariableAssignment,
     VariableType,
     as_basic_type,
 )
@@ -149,7 +149,7 @@ def convert_statement(statement: Statement, full=False) -> str:
         return convert_function_call(statement)
     elif isinstance(statement, Value):
         return convert_value(statement)
-    elif isinstance(statement, Assignment):
+    elif isinstance(statement, VariableAssignment):
         if full:
             prefix = convert_declaration(statement.type) + " "
         else:

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -30,7 +30,7 @@ from tested.languages.preparation import (
     prepare_expression,
 )
 from tested.parsing import get_converter
-from tested.serialisation import Assignment, Expression, Statement, VariableType
+from tested.serialisation import Expression, Statement, VariableType
 from tested.testsuite import (
     Context,
     FileUrl,
@@ -39,6 +39,7 @@ from tested.testsuite import (
     Testcase,
     TextData,
 )
+from tested.utils import is_statement_strict
 
 if TYPE_CHECKING:
     from tested.judge.planning import PlannedExecutionUnit
@@ -232,7 +233,7 @@ def generate_statement(bundle: Bundle, statement: Statement) -> str:
     if isinstance(statement, Expression):
         statement = prepare_expression(bundle, statement)
     else:
-        assert isinstance(statement, Assignment)
+        assert is_statement_strict(statement)
         statement = prepare_assignment(bundle, statement)
 
     return bundle.language.generate_statement(statement)

--- a/tested/languages/haskell/generators.py
+++ b/tested/languages/haskell/generators.py
@@ -20,7 +20,6 @@ from tested.languages.preparation import (
 )
 from tested.languages.utils import convert_unknown_type
 from tested.serialisation import (
-    Assignment,
     Expression,
     FunctionCall,
     Identifier,
@@ -30,6 +29,7 @@ from tested.serialisation import (
     Statement,
     StringType,
     Value,
+    VariableAssignment,
     VariableType,
     as_basic_type,
 )
@@ -161,7 +161,7 @@ def convert_statement(statement: Statement, lifting=False) -> str:
             result += ")"
         return result
     else:
-        assert isinstance(statement, Assignment)
+        assert isinstance(statement, VariableAssignment)
         return f"let {statement.variable} = {convert_statement(statement.expression)}"
 
 

--- a/tested/languages/java/generators.py
+++ b/tested/languages/java/generators.py
@@ -23,17 +23,18 @@ from tested.languages.preparation import (
 )
 from tested.languages.utils import convert_unknown_type, is_special_void_call
 from tested.serialisation import (
-    Assignment,
     Expression,
     FunctionCall,
     FunctionType,
     Identifier,
     ObjectType,
+    PropertyAssignment,
     SequenceType,
     SpecialNumbers,
     Statement,
     StringType,
     Value,
+    VariableAssignment,
     VariableType,
     as_basic_type,
 )
@@ -239,7 +240,12 @@ def convert_statement(statement: Statement, full=False) -> str:
         return convert_function_call(statement)
     elif isinstance(statement, Value):
         return convert_value(statement)
-    elif isinstance(statement, Assignment):
+    elif isinstance(statement, PropertyAssignment):
+        return (
+            f"{convert_statement(statement.property)} = "
+            f"{convert_statement(statement.expression)}"
+        )
+    elif isinstance(statement, VariableAssignment):
         if full:
             prefix = convert_declaration(statement.type, statement.expression) + " "
         else:
@@ -259,12 +265,12 @@ def _generate_internal_context(ctx: PreparedContext, pu: PreparedExecutionUnit) 
     for tc in ctx.testcases:
         result += "this.writeSeparator();\n"
 
-        # In Java, we need special code to make variables available outside of
+        # In Java, we need special code to make variables available outside
         # the try-catch block.
         if (
             not tc.testcase.is_main_testcase()
             and isinstance(tc.input, PreparedTestcaseStatement)
-            and isinstance(tc.input.statement, Assignment)
+            and isinstance(tc.input.statement, VariableAssignment)
         ):
             result += (
                 convert_declaration(

--- a/tested/languages/javascript/generators.py
+++ b/tested/languages/javascript/generators.py
@@ -21,17 +21,18 @@ from tested.languages.preparation import (
 )
 from tested.languages.utils import convert_unknown_type
 from tested.serialisation import (
-    Assignment,
     Expression,
     FunctionCall,
     FunctionType,
     Identifier,
     ObjectType,
+    PropertyAssignment,
     SequenceType,
     SpecialNumbers,
     Statement,
     StringType,
     Value,
+    VariableAssignment,
     as_basic_type,
 )
 from tested.testsuite import MainInput
@@ -129,7 +130,12 @@ def convert_statement(statement: Statement, internal=False, full=False) -> str:
         return convert_function_call(statement, internal)
     elif isinstance(statement, Value):
         return convert_value(statement)
-    elif isinstance(statement, Assignment):
+    elif isinstance(statement, PropertyAssignment):
+        return (
+            f"{convert_statement(statement.property, True)} = "
+            f"{convert_statement(statement.expression, True)}"
+        )
+    elif isinstance(statement, VariableAssignment):
         if full:
             prefix = "let "
         else:
@@ -172,7 +178,7 @@ def _generate_internal_context(ctx: PreparedContext, pu: PreparedExecutionUnit) 
         if (
             not tc.testcase.is_main_testcase()
             and isinstance(tc.input, PreparedTestcaseStatement)
-            and isinstance(tc.input.statement, Assignment)
+            and isinstance(tc.input.statement, VariableAssignment)
         ):
             result += f"let {tc.input.statement.variable}\n"
 

--- a/tested/languages/kotlin/generators.py
+++ b/tested/languages/kotlin/generators.py
@@ -30,11 +30,13 @@ from tested.serialisation import (
     Identifier,
     NamedArgument,
     ObjectType,
+    PropertyAssignment,
     SequenceType,
     SpecialNumbers,
     Statement,
     StringType,
     Value,
+    VariableAssignment,
     VariableType,
     as_basic_type,
 )
@@ -244,7 +246,12 @@ def convert_statement(statement: Statement, full=False) -> str:
         return convert_function_call(statement)
     elif isinstance(statement, Value):
         return convert_value(statement)
-    elif isinstance(statement, Assignment):
+    elif isinstance(statement, PropertyAssignment):
+        return (
+            f"{convert_statement(statement.property)} = "
+            f"{convert_statement(statement.expression)};"
+        )
+    elif isinstance(statement, VariableAssignment):
         prefix = "var " if full else ""
         return (
             f"{prefix}{statement.variable} = "
@@ -320,7 +327,7 @@ class {pu.unit.name}: AutoCloseable {{
             if (
                 not tc.testcase.is_main_testcase()
                 and isinstance(tc.input, PreparedTestcaseStatement)
-                and isinstance(tc.input.statement, Assignment)
+                and isinstance(tc.input.statement, VariableAssignment)
             ):
                 decl = convert_declaration(
                     tc.input.statement.type, tc.input.statement.expression

--- a/tested/languages/python/generators.py
+++ b/tested/languages/python/generators.py
@@ -26,11 +26,13 @@ from tested.serialisation import (
     Identifier,
     NamedArgument,
     ObjectType,
+    PropertyAssignment,
     SequenceType,
     SpecialNumbers,
     Statement,
     StringType,
     Value,
+    VariableAssignment,
     as_basic_type,
 )
 from tested.testsuite import MainInput
@@ -127,7 +129,12 @@ def convert_statement(statement: Statement, with_namespace=False) -> str:
         return convert_function_call(statement, with_namespace)
     elif isinstance(statement, Value):
         return convert_value(statement)
-    elif isinstance(statement, Assignment):
+    elif isinstance(statement, PropertyAssignment):
+        return (
+            f"{convert_statement(statement.property)} = "
+            f"{convert_statement(statement.expression, with_namespace)}"
+        )
+    elif isinstance(statement, VariableAssignment):
         return (
             f"{statement.variable} = "
             f"{convert_statement(statement.expression, with_namespace)}"

--- a/tests/exercises/objects/evaluation/property_assignment.yaml
+++ b/tests/exercises/objects/evaluation/property_assignment.yaml
@@ -1,0 +1,7 @@
+- tab: "Feedback"
+  contexts:
+    - testcases:
+        - statement: 'instance = Equal_checker(10)'
+        - statement: 'instance.prop = 5'
+        - expression: 'instance.prop'
+          return: 5

--- a/tests/exercises/objects/solution/correct.cs
+++ b/tests/exercises/objects/solution/correct.cs
@@ -1,6 +1,7 @@
 public class EqualChecker {
 
     private readonly int number;
+    public int Prop = 0;
 
     public EqualChecker(int number) {
         this.number = number;

--- a/tests/exercises/objects/solution/correct.java
+++ b/tests/exercises/objects/solution/correct.java
@@ -3,6 +3,7 @@ import java.util.*;
 class EqualChecker {
 
     private final int number;
+    public int prop = 0;
 
     EqualChecker(int number) {
         this.number = number;

--- a/tests/exercises/objects/solution/correct.kt
+++ b/tests/exercises/objects/solution/correct.kt
@@ -1,4 +1,7 @@
 class EqualChecker(private val value: Any?) {
+
+    var prop: Int = 0;
+
     fun check(other: Any?): Boolean {
         return other == value
     }

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -19,12 +19,12 @@ from tested.datatypes import (
 )
 from tested.dsl import parse_dsl, translate_to_test_suite
 from tested.serialisation import (
-    Assignment,
     FunctionCall,
     NumberType,
     ObjectType,
     SequenceType,
     StringType,
+    VariableAssignment,
 )
 from tested.testsuite import (
     CustomCheckOracle,
@@ -281,14 +281,14 @@ def test_statements():
     tests0, tests1 = ctx0.testcases, ctx1.testcases
 
     assert len(tests0) == 2
-    assert isinstance(tests0[0].input, Assignment)
+    assert isinstance(tests0[0].input, VariableAssignment)
     assert tests0[0].output.stdout.data == "New safe\n"
     assert tests0[0].output.stdout.oracle.options["ignoreWhitespace"]
     assert isinstance(tests0[1].input, FunctionCall)
     assert tests0[1].output.result.value.data == "Ignore whitespace"
 
     assert len(tests1) == 2
-    assert isinstance(tests1[0].input, Assignment)
+    assert isinstance(tests1[0].input, VariableAssignment)
     assert tests1[0].output.stdout.data == "New safe\n"
     assert not tests1[0].output.stdout.oracle.options["ignoreWhitespace"]
     assert isinstance(tests1[1].input, FunctionCall)

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -698,6 +698,24 @@ def test_objects_chained(language: str, tmp_path: Path, pytestconfig):
 @pytest.mark.parametrize(
     "language", ["python", "java", "kotlin", "javascript", "csharp"]
 )
+def test_property_assignment(language: str, tmp_path: Path, pytestconfig):
+    conf = configuration(
+        pytestconfig,
+        "objects",
+        language,
+        tmp_path,
+        "property_assignment.yaml",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"] * 1
+    assert len(updates.find_all("start-testcase")) == 3
+
+
+@pytest.mark.parametrize(
+    "language", ["python", "java", "kotlin", "javascript", "csharp"]
+)
 def test_counter(language: str, tmp_path: Path, pytestconfig):
     conf = configuration(
         pytestconfig, "counter", language, tmp_path, "plan.yaml", "solution"


### PR DESCRIPTION
For example:

```python
instance = Object()
instance.prop = 56
```

Most of the infrastructure to support this was already in place since we support reading properties, and we already support assignments.

Using this requires languages to support both object-orientation and assignments (so e.g. C structs are out).

Fixes #500 
