### PR TITLE
Support "raw" identifiers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
               export DOTNET_CLI_HOME
               NODE_PATH=${ast}/lib/node_modules
               export NODE_PATH
-              poetry run pytest -n auto --cov=tested --cov-report=xml tests/test_functionality.py
+              poetry run pytest -n auto --cov=tested --cov-report=xml tests/
             '';
             installPhase = ''
               mkdir -p $out

--- a/tested/descriptions/converters.py
+++ b/tested/descriptions/converters.py
@@ -22,6 +22,7 @@ from tested.languages.conventionalize import (
     conventionalize_property,
 )
 from tested.languages.generation import NestedTypeDeclaration, generate_type_declaration
+from tested.serialisation import Identifier
 from tested.testsuite import LanguageMapping
 from tested.utils import get_args
 
@@ -157,7 +158,7 @@ def _construct_datatype(
 
 
 def _support_language_specific_arguments(
-    normal: Callable[[Language, str], str],
+    normal: Callable[[Language, Identifier], Identifier],
     bundle: Bundle,
     actual: str | LanguageMapping,
 ) -> str:
@@ -168,7 +169,7 @@ def _support_language_specific_arguments(
         )
         return actual[bundle.config.programming_language]
     else:
-        return normal(bundle.language, actual)
+        return normal(bundle.language, Identifier(actual))
 
 
 def convert_templated_problem(bundle: Bundle, raw_description: str) -> str:

--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -33,6 +33,7 @@ from tested.dsl.ast_translator import parse_string
 from tested.parsing import get_converter, suite_to_json
 from tested.serialisation import (
     BooleanType,
+    Identifier,
     NothingType,
     NumberType,
     ObjectKeyValuePair,
@@ -603,7 +604,7 @@ def _convert_dsl(dsl_object: YamlObject) -> Suite:
 
     if namespace:
         assert isinstance(namespace, str)
-        return Suite(tabs=tabs, namespace=namespace)
+        return Suite(tabs=tabs, namespace=Identifier(namespace))
     else:
         return Suite(tabs=tabs)
 

--- a/tested/languages/bash/generators.py
+++ b/tested/languages/bash/generators.py
@@ -249,7 +249,7 @@ function send_value {{
     for value in values:
         index_fun = unique_index_function()
         function_call = FunctionCall(
-            type=FunctionType.FUNCTION, name="send_value", arguments=[value]
+            type=FunctionType.FUNCTION, name=Identifier("send_value"), arguments=[value]
         )
         result += f"{convert_function_call(function_call, index_fun, [])}\n"
     return result

--- a/tested/languages/conventionalize.py
+++ b/tested/languages/conventionalize.py
@@ -6,13 +6,15 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
+from tested.serialisation import Identifier
+
 if TYPE_CHECKING:
     from tested.languages import Language
 
 _logger = logging.getLogger(__name__)
 
 
-EXECUTION_PREFIX = "execution"
+EXECUTION_PREFIX = Identifier("execution")
 
 
 def camel_snake_case(what: str) -> str:
@@ -335,14 +337,17 @@ _case_mapping: dict[NamingConventions, Callable[[str], str]] = {
 
 
 def _conventionalize(
-    language: "Language", what: Conventionable, identifier: str
-) -> str:
+    language: "Language", what: Conventionable, identifier: Identifier
+) -> Identifier:
+    if identifier.is_raw:
+        return identifier
     conventions = language.naming_conventions()
     mapper = _case_mapping[conventions.get(what, "snake_case")]
-    return mapper(identifier)
+    result = mapper(identifier)
+    return Identifier(result)
 
 
-def conventionalize_class(language: "Language", class_name: str) -> str:
+def conventionalize_class(language: "Language", class_name: Identifier) -> Identifier:
     """
     Conventionalize a class name.
 
@@ -353,7 +358,9 @@ def conventionalize_class(language: "Language", class_name: str) -> str:
     return _conventionalize(language, "class", class_name)
 
 
-def conventionalize_function(language: "Language", function_name: str) -> str:
+def conventionalize_function(
+    language: "Language", function_name: Identifier
+) -> Identifier:
     """
     Conventionalize the name of a function.
 
@@ -364,7 +371,9 @@ def conventionalize_function(language: "Language", function_name: str) -> str:
     return _conventionalize(language, "function", function_name)
 
 
-def conventionalize_identifier(language: "Language", identifier: str) -> str:
+def conventionalize_identifier(
+    language: "Language", identifier: Identifier
+) -> Identifier:
     """
     Conventionalize the name of an identifier.
 
@@ -375,7 +384,9 @@ def conventionalize_identifier(language: "Language", identifier: str) -> str:
     return _conventionalize(language, "identifier", identifier)
 
 
-def conventionalize_global_identifier(language: "Language", identifier: str) -> str:
+def conventionalize_global_identifier(
+    language: "Language", identifier: Identifier
+) -> Identifier:
     """
     Conventionalize the name of a global identifier.
 
@@ -386,7 +397,9 @@ def conventionalize_global_identifier(language: "Language", identifier: str) -> 
     return _conventionalize(language, "global_identifier", identifier)
 
 
-def conventionalize_namespace(language: "Language", namespace: str) -> str:
+def conventionalize_namespace(
+    language: "Language", namespace: Identifier
+) -> Identifier:
     """
     Conventionalize a namespace.
 
@@ -402,7 +415,9 @@ def conventionalize_namespace(language: "Language", namespace: str) -> str:
     return _conventionalize(language, "namespace", namespace)
 
 
-def conventionalize_property(language: "Language", property_name: str) -> str:
+def conventionalize_property(
+    language: "Language", property_name: Identifier
+) -> Identifier:
     """
     Conventionalize the name of a property.
 
@@ -414,7 +429,7 @@ def conventionalize_property(language: "Language", property_name: str) -> str:
     return _conventionalize(language, "property", property_name)
 
 
-def submission_name(language: "Language") -> str:
+def submission_name(language: "Language") -> Identifier:
     """
     :return: The name of a submission.
     """
@@ -429,11 +444,11 @@ def submission_file(language: "Language") -> str:
     return language.submission_file()
 
 
-def selector_name(language: "Language") -> str:
+def selector_name(language: "Language") -> Identifier:
     """
     :return: The name for the selector, conventionalized.
     """
-    return conventionalize_namespace(language, "selector")
+    return conventionalize_namespace(language, Identifier("selector"))
 
 
 def selector_file(language: "Language") -> str:
@@ -443,7 +458,7 @@ def selector_file(language: "Language") -> str:
     return language.with_extension(selector_name(language))
 
 
-def execution_name(language: "Language", execution_number: int) -> str:
+def execution_name(language: "Language", execution_number: int) -> Identifier:
     """
     Get the name of an execution. The name should be unique for the tab and
     execution number combination.
@@ -452,5 +467,5 @@ def execution_name(language: "Language", execution_number: int) -> str:
     :param execution_number: The number of the execution.
     :return: The name of the execution.
     """
-    name = f"{EXECUTION_PREFIX}_{execution_number}"
+    name = Identifier(f"{EXECUTION_PREFIX}_{execution_number}")
     return conventionalize_namespace(language, name)

--- a/tested/languages/preparation.py
+++ b/tested/languages/preparation.py
@@ -204,7 +204,9 @@ def prepare_argument(
 def prepare_assignment(bundle: Bundle, assignment: Assignment) -> Assignment:
     if isinstance(assignment, VariableAssignment):
         if isinstance(assignment.type, VariableType):
-            class_type = conventionalize_class(bundle.language, assignment.type.data)
+            class_type = conventionalize_class(
+                bundle.language, Identifier(assignment.type.data)
+            )
             assignment = assignment.replace_type(VariableType(data=class_type))
 
         assignment = assignment.replace_variable(
@@ -309,7 +311,9 @@ def _create_handling_function(
         output.oracle, LanguageSpecificOracle
     ):
         evaluator = output.oracle.for_language(bundle.config.programming_language)
-        evaluator_name = conventionalize_namespace(lang_config, evaluator.file.stem)
+        evaluator_name = conventionalize_namespace(
+            lang_config, Identifier(evaluator.file.stem)
+        )
     else:
         evaluator_name = None
         evaluator = None
@@ -319,10 +323,13 @@ def _create_handling_function(
             output.oracle, LanguageSpecificOracle
         ):
             assert evaluator
+            assert evaluator_name
             arguments = [
                 PreparedFunctionCall(
                     type=FunctionType.FUNCTION,
-                    name=conventionalize_function(lang_config, evaluator.name),
+                    name=conventionalize_function(
+                        lang_config, Identifier(evaluator.name)
+                    ),
                     namespace=Identifier(evaluator_name),
                     arguments=[prepare_expression(bundle, expression)],
                     has_root_namespace=False,
@@ -335,7 +342,7 @@ def _create_handling_function(
 
         internal = PreparedFunctionCall(
             type=FunctionType.FUNCTION,
-            name=conventionalize_function(lang_config, function_name),
+            name=conventionalize_function(lang_config, Identifier(function_name)),
             arguments=[prepare_argument(bundle, arg) for arg in arguments],
             has_root_namespace=False,
         )

--- a/tested/oracles/programmed.py
+++ b/tested/oracles/programmed.py
@@ -98,18 +98,22 @@ def _evaluate_programmed(
 
     # The context in which to execute.
     global_env = {
-        "__tested_test__": utils,
-        "__tested_context__": ConvertedOracleContext.from_context(eval_bundle, context),
+        "t__tested_test__": utils,
+        "t__tested_context__": ConvertedOracleContext.from_context(
+            eval_bundle, context
+        ),
     }
-    exec("import sys\n" "sys.modules['evaluation_utils'] = __tested_test__", global_env)
+    exec(
+        "import sys\n" "sys.modules['evaluation_utils'] = t__tested_test__", global_env
+    )
     # Make the oracle available.
     exec(evaluator_code, global_env)
 
     # Since we pass a class value, we don't want to
     check_function_call = FunctionCall(
         type=FunctionType.FUNCTION,
-        name=oracle.function.name,
-        arguments=[Identifier("__tested_context__"), *oracle.arguments],
+        name=Identifier(oracle.function.name),
+        arguments=[Identifier("t__tested_context__"), *oracle.arguments],
     )
     literal_function_call = generate_statement(eval_bundle, check_function_call)
 

--- a/tested/testsuite.py
+++ b/tested/testsuite.py
@@ -34,6 +34,7 @@ from tested.serialisation import (
     Expression,
     FunctionCall,
     FunctionType,
+    Identifier,
     NamedArgument,
     SequenceType,
     Statement,
@@ -717,7 +718,7 @@ class Suite(WithFeatures, WithFunctions):
     """General test suite, which is used to run tests of some code."""
 
     tabs: list[Tab] = field(factory=list)
-    namespace: str = "submission"
+    namespace: Identifier = Identifier("submission")
 
     def get_used_features(self) -> FeatureSet:
         """

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -17,7 +17,7 @@ from tested.dodona import (
 )
 from tested.judge.collector import OutputManager
 from tested.judge.evaluation import terminate
-from tested.serialisation import FunctionCall, FunctionType
+from tested.serialisation import FunctionCall, FunctionType, Identifier
 from tested.testsuite import (
     Context,
     MainInput,
@@ -41,7 +41,9 @@ TEST_SUITE = Suite(
                         ),
                         Testcase(
                             input=FunctionCall(
-                                type=FunctionType.FUNCTION, name="test 2", arguments=[]
+                                type=FunctionType.FUNCTION,
+                                name=Identifier("test 2"),
+                                arguments=[],
                             ),
                             output=Output(),
                         ),
@@ -51,7 +53,9 @@ TEST_SUITE = Suite(
                     testcases=[
                         Testcase(
                             input=FunctionCall(
-                                type=FunctionType.FUNCTION, name="test 22", arguments=[]
+                                type=FunctionType.FUNCTION,
+                                name=Identifier("test 22"),
+                                arguments=[],
                             ),
                             output=Output(),
                         ),
@@ -67,7 +71,7 @@ TEST_SUITE = Suite(
                         Testcase(
                             input=FunctionCall(
                                 type=FunctionType.FUNCTION,
-                                name="test 2.1",
+                                name=Identifier("test 2.1"),
                                 arguments=[],
                             ),
                             output=Output(),

--- a/tests/test_dsl_expression.py
+++ b/tests/test_dsl_expression.py
@@ -461,6 +461,31 @@ def test_parse_function():
     assert len(value.arguments) == 0
 
 
+def test_parse_raw_capitalization_function():
+    function = parse_string("__TheFunction__(5)")
+    assert isinstance(function, FunctionCall)
+    assert function.type == FunctionType.FUNCTION
+    assert function.namespace is None
+    assert function.name == "TheFunction"
+    assert len(function.arguments) == 1
+    arg = function.arguments[0]
+    assert arg.type == BasicNumericTypes.INTEGER
+
+
+def test_parse_raw_capitalization_property():
+    function = parse_string("__test__.__some_class__")
+    assert isinstance(function, FunctionCall)
+    assert function.type == FunctionType.PROPERTY
+    assert function.namespace == "test"
+    assert function.name == "some_class"
+
+
+def test_parse_raw_capitalization_variable():
+    assign = parse_string("__test__ = 5")
+    assert isinstance(assign, VariableAssignment)
+    assert assign.variable == "test"
+
+
 def test_parse_identifier():
     parsed = parse_string("id")
     assert isinstance(parsed, Identifier)

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -23,6 +23,7 @@ from tested.serialisation import (
     BooleanType,
     FunctionCall,
     FunctionType,
+    Identifier,
     NumberType,
     StringType,
 )
@@ -895,7 +896,7 @@ def test_function_arguments_without_brackets(tmp_path: Path, pytestconfig):
 
     statement = FunctionCall(
         type=FunctionType.FUNCTION,
-        name="test",
+        name=Identifier("test"),
         namespace=None,
         arguments=[
             NumberType(type=BasicNumericTypes.REAL, data=5.5),

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -2,13 +2,13 @@
 Test the serialization format.
 
 While the normal exercise-based tests already use serialization,
-they don't actually test all datatypes and such.
+they do not test all datatypes and such.
 
 To make testing easy, your language module needs to implement an "encode" template.
 This template takes one value and must pass it to the "values" module.
 
-Testing advanced types is a work-in progress at this point, since we test in Python,
-and Python doesn't have explicit support for e.g. int32, int64.
+Testing advanced types is work-in progress at this point, since we test in Python,
+and Python does not have explicit support for e.g. int32, int64.
 """
 
 import itertools
@@ -42,6 +42,7 @@ from tested.languages.conventionalize import conventionalize_namespace
 from tested.oracles.value import _check_simple_type
 from tested.serialisation import (
     BooleanType,
+    Identifier,
     NothingType,
     NumberType,
     ObjectKeyValuePair,
@@ -192,7 +193,7 @@ def run_encoder(bundle: Bundle, values: list[Value]) -> list[str]:
     dest = bundle.config.workdir
     copy_from_paths_to_path(dependency_paths, dependencies, dest)
 
-    name = conventionalize_namespace(bundle.language, "encode")
+    name = conventionalize_namespace(bundle.language, Identifier("encode"))
     encoder_name = bundle.language.with_extension(name)
     encoder_destination = dest / encoder_name
     encode_code = bundle.language.generate_encoder(values)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,4 +1,5 @@
 from tested.parsing import get_converter
+from tested.serialisation import FunctionCall, FunctionType
 from tested.testsuite import (
     CustomCheckOracle,
     ExceptionOutputChannel,
@@ -146,3 +147,16 @@ def test_exit_show_expected_is_accepted():
     """
     result = get_converter().loads(scheme, ExitCodeOutputChannel)
     assert result.value == 0
+
+
+def test_generic_functions_are_kept():
+    scheme = """
+    {
+        "type": "function",
+        "name": "__TeSt__"
+    }
+    """
+    result = get_converter().loads(scheme, FunctionCall)
+    assert result.type == FunctionType.FUNCTION
+    assert result.name == "TeSt"
+    assert result.name.is_raw


### PR DESCRIPTION
Using `__X__` as identifiers for those that need to be kept as is, e.g. not conventionalised is a mostly nice way of doing it.

One thing that still needs to consider is how to do constructors. Since we use the convention that a constructor needs to start with a capital, which no longer works.

One solution, e.g. `new__X__`, is ugly and difficult to implement. Another would be to add e.g. a new function, to allow writing `constructor(__X__, *arguments)`.

This works cleanly, but is also not that nice.

Fixes #326.