### PR TITLE
Pass location of source code in oracle context

### DIFF
--- a/tested/dsl/schema-strict.json
+++ b/tested/dsl/schema-strict.json
@@ -530,6 +530,13 @@
               "items" : {
                 "$ref" : "#/definitions/yamlValueOrPythonExpression"
               }
+            },
+            "languages": {
+              "type" : "array",
+              "description" : "Which programming languages are supported by this oracle.",
+              "items" : {
+                "$ref" : "#/definitions/programmingLanguage"
+              }
             }
           }
         }
@@ -584,6 +591,13 @@
               "description" : "List of YAML (or tagged expression) values to use as arguments to the function.",
               "items" : {
                 "$ref" : "#/definitions/yamlValueOrPythonExpression"
+              }
+            },
+            "languages": {
+              "type" : "array",
+              "description" : "Which programming languages are supported by this oracle.",
+              "items" : {
+                "$ref" : "#/definitions/programmingLanguage"
               }
             }
           }

--- a/tested/dsl/schema.json
+++ b/tested/dsl/schema.json
@@ -530,6 +530,13 @@
               "items" : {
                 "$ref" : "#/definitions/yamlValueOrPythonExpression"
               }
+            },
+            "languages": {
+              "type" : "array",
+              "description" : "Which programming languages are supported by this oracle.",
+              "items" : {
+                "$ref" : "#/definitions/programmingLanguage"
+              }
             }
           }
         }
@@ -584,6 +591,13 @@
               "description" : "List of YAML (or tagged expression) values to use as arguments to the function.",
               "items" : {
                 "$ref" : "#/definitions/yamlValueOrPythonExpression"
+              }
+            },
+            "languages": {
+              "type" : "array",
+              "description" : "Which programming languages are supported by this oracle.",
+              "items" : {
+                "$ref" : "#/definitions/programmingLanguage"
               }
             }
           }

--- a/tested/oracles/common.py
+++ b/tested/oracles/common.py
@@ -37,16 +37,22 @@ from tested.languages.generation import generate_statement
 from tested.languages.utils import convert_stacktrace_to_clickable_feedback
 from tested.parsing import fallback_field, get_converter
 from tested.serialisation import Value
-from tested.testsuite import ExceptionOutputChannel, NormalOutputChannel, OutputChannel
+from tested.testsuite import (
+    ExceptionOutputChannel,
+    NormalOutputChannel,
+    OutputChannel,
+    SupportedLanguage,
+)
 
 
 @define
 class OracleContext:
     expected: Value
     actual: Value
-    execution_directory: str
-    evaluation_directory: str
-    programming_language: str
+    execution_directory: Path
+    evaluation_directory: Path
+    submission_path: Path | None
+    programming_language: SupportedLanguage
     natural_language: str
 
 

--- a/tested/oracles/programmed.py
+++ b/tested/oracles/programmed.py
@@ -32,12 +32,18 @@ DEFAULT_STUDENT = get_i18n_string("oracles.programmed.student.default")
 
 @define
 class ConvertedOracleContext:
+    """
+    This is the oracle context that is passed to the actual function.
+    It should thus remain backwards compatible.
+    """
+
     expected: Any
     actual: Any
     execution_directory: str
     evaluation_directory: str
     programming_language: str
     natural_language: str
+    submission_path: str | None
 
     @staticmethod
     def from_context(
@@ -46,10 +52,15 @@ class ConvertedOracleContext:
         return ConvertedOracleContext(
             expected=eval(generate_statement(bundle, context.expected)),
             actual=eval(generate_statement(bundle, context.actual)),
-            execution_directory=context.execution_directory,
-            evaluation_directory=context.evaluation_directory,
+            execution_directory=str(context.execution_directory.absolute()),
+            evaluation_directory=str(context.evaluation_directory.absolute()),
             programming_language=context.programming_language,
             natural_language=context.natural_language,
+            submission_path=(
+                str(context.submission_path.absolute())
+                if context.submission_path
+                else None
+            ),
         )
 
 
@@ -237,10 +248,13 @@ def evaluate(
     context = OracleContext(
         expected=expected,
         actual=actual,
-        execution_directory=str(config.context_dir.absolute()),
-        evaluation_directory=str(config.bundle.config.resources.absolute()),
-        programming_language=str(config.bundle.config.programming_language),
+        execution_directory=config.context_dir,
+        evaluation_directory=config.bundle.config.resources,
+        programming_language=config.bundle.config.programming_language,
         natural_language=config.bundle.config.natural_language,
+        submission_path=(
+            config.bundle.config.source if channel.oracle.languages else None
+        ),
     )
     result = _evaluate_programmed(config.bundle, channel.oracle, context)
 

--- a/tests/exercises/lotto/evaluation/evaluator.py
+++ b/tests/exercises/lotto/evaluation/evaluator.py
@@ -1,4 +1,5 @@
 import re
+import ast
 # noinspection PyUnresolvedReferences
 from evaluation_utils import EvaluationResult, Message
 
@@ -48,3 +49,33 @@ def evaluate(context, count, maximum):
     if valid:
         expected = actual
     return EvaluationResult(valid, expected, actual, messages)
+
+
+def check_for_node(search, context, count, maximum):
+    assert context.programming_language == "python", "This exercise only supports Python"
+    # Check if the submission uses a while loop.
+    with open(context.submission_path, "r") as submission_file:
+        submission = submission_file.read()
+
+    # This has no error handling, so it is not ready for production.
+    nodes = ast.walk(ast.parse(submission))
+    has_while = any(isinstance(node, search) for node in nodes)
+    messages = []
+    if not has_while:
+        messages.append("Your code does not use a while loop, which is mandatory.")
+    eval_result = evaluate(context, count, maximum)
+
+    return EvaluationResult(
+        eval_result.result and has_while,
+        eval_result.readable_expected,
+        eval_result.readable_actual,
+        eval_result.messages + messages
+    )
+
+
+def check_for_while(context, count, maximum):
+    return check_for_node(ast.While, context, count, maximum)
+
+
+def check_for_for(context, count, maximum):
+    return check_for_node(ast.For, context, count, maximum)

--- a/tests/exercises/lotto/evaluation/one-programmed-analysis-correct.yaml
+++ b/tests/exercises/lotto/evaluation/one-programmed-analysis-correct.yaml
@@ -1,0 +1,10 @@
+- tab: "Feedback"
+  testcases:
+    - expression: "loterij(18, 172)"
+      return: !oracle
+        oracle: "custom_check"
+        file: "evaluator.py"
+        name: "check_for_while"
+        value: "7 - 37 - 48 - 54 - 70 - 78 - 81 - 90 - 102 - 103 - 113 - 119 - 120 - 137 - 140 - 154 - 157 - 159"
+        arguments: [18, 172]
+        languages: ["python"]

--- a/tests/exercises/lotto/evaluation/one-programmed-analysis-without-language.yaml
+++ b/tests/exercises/lotto/evaluation/one-programmed-analysis-without-language.yaml
@@ -1,0 +1,9 @@
+- tab: "Feedback"
+  testcases:
+    - expression: "loterij(18, 172)"
+      return: !oracle
+        oracle: "custom_check"
+        file: "evaluator.py"
+        name: "check_for_while"
+        value: "7 - 37 - 48 - 54 - 70 - 78 - 81 - 90 - 102 - 103 - 113 - 119 - 120 - 137 - 140 - 154 - 157 - 159"
+        arguments: [18, 172]

--- a/tests/exercises/lotto/evaluation/one-programmed-analysis-wrong.yaml
+++ b/tests/exercises/lotto/evaluation/one-programmed-analysis-wrong.yaml
@@ -1,0 +1,10 @@
+- tab: "Feedback"
+  testcases:
+    - expression: "loterij(18, 172)"
+      return: !oracle
+        oracle: "custom_check"
+        file: "evaluator.py"
+        name: "check_for_for"
+        value: "7 - 37 - 48 - 54 - 70 - 78 - 81 - 90 - 102 - 103 - 113 - 119 - 120 - 137 - 140 - 154 - 157 - 159"
+        arguments: [18, 172]
+        languages: ["python"]

--- a/tests/test_oracles_builtin.py
+++ b/tests/test_oracles_builtin.py
@@ -26,6 +26,7 @@ from tested.testsuite import (
     ExpectedException,
     FileOutputChannel,
     Suite,
+    SupportedLanguage,
     TextOutputChannel,
     ValueOutputChannel,
 )
@@ -317,7 +318,10 @@ def test_exception_oracle_correct_message_wrong_type(
     channel = ExceptionOutputChannel(
         exception=ExpectedException(
             message="Test error",
-            types={"python": "PiefError", "javascript": "PafError"},
+            types={
+                SupportedLanguage.PYTHON: "PiefError",
+                SupportedLanguage.JAVASCRIPT: "PafError",
+            },
         )
     )
     actual_value = get_converter().dumps(
@@ -345,7 +349,10 @@ def test_exception_oracle_wrong_message_correct_type(
     channel = ExceptionOutputChannel(
         exception=ExpectedException(
             message="Test error",
-            types={"python": "PiefError", "javascript": "PafError"},
+            types={
+                SupportedLanguage.PYTHON: "PiefError",
+                SupportedLanguage.JAVASCRIPT: "PafError",
+            },
         )
     )
 
@@ -376,7 +383,10 @@ def test_exception_oracle_correct_type_and_message(
     channel = ExceptionOutputChannel(
         exception=ExpectedException(
             message="Test error",
-            types={"python": "PiefError", "javascript": "PafError"},
+            types={
+                SupportedLanguage.PYTHON: "PiefError",
+                SupportedLanguage.JAVASCRIPT: "PafError",
+            },
         )
     )
 

--- a/tests/test_oracles_programmed.py
+++ b/tests/test_oracles_programmed.py
@@ -130,3 +130,56 @@ def test_custom_check_function_lotto_wrong(
     assert len(updates.find_all("start-testcase")) == 1
     assert updates.find_status_enum() == ["wrong"]
     assert len(updates.find_all("append-message")) == 1
+
+
+def test_custom_check_function_static_analysis_correct(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    conf = configuration(
+        pytestconfig,
+        "lotto",
+        "python",
+        tmp_path,
+        "one-programmed-analysis-correct.yaml",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("start-testcase")) == 1
+    assert updates.find_status_enum() == ["correct"]
+    assert len(updates.find_all("append-message")) == 0
+
+
+def test_custom_check_function_static_analysis_wrong(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    conf = configuration(
+        pytestconfig,
+        "lotto",
+        "python",
+        tmp_path,
+        "one-programmed-analysis-wrong.yaml",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("start-testcase")) == 1
+    assert updates.find_status_enum() == ["wrong"]
+    assert len(updates.find_all("append-message")) == 1
+
+
+def test_custom_check_function_static_analysis_missing_language(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    conf = configuration(
+        pytestconfig,
+        "lotto",
+        "python",
+        tmp_path,
+        "one-programmed-analysis-without-language.yaml",
+        "correct",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert len(updates.find_all("start-testcase")) == 1
+    assert updates.find_status_enum() == ["internal error"]


### PR DESCRIPTION
This is a small change/experiment:
- allowing limiting which languages a custom check oracle supports
- if this list of languages is present, pass the location of the source code to the custom check functions of the programmed oracles.

The intended use of this would be to provide a semi-supported way of doing static analysis of the code of the submission. The reasons for doing this are:

- We do have demand for this (and other, proper, solutions is long-term research: #392 )
- We do not have to point people wanting to do this to the Python judge if this is implemented.
- The maintenance burden and backwards compatibility story for us is very minimal: we just pass the path to the submission in the oracle context. We are not committing to allowing static checks specifically.

An alternative, doing this in the language-specific oracles forces the use of language-specific oracles, which are much harder to properly implement than the programmed ones.

I would certainly not include an example of using this for static checks in the documentation: we do not want to encourage this. The main question is thus do we actually want to make this possible or not?