### PR TITLE
Fix/tested haskell judge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ venv-*/
 .venv/
 node_modules/
 result/
+.data/

--- a/tested/languages/haskell/config.py
+++ b/tested/languages/haskell/config.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from tested.datatypes import AllTypes
 from tested.dodona import AnnotateCode, Message
@@ -28,6 +28,10 @@ if TYPE_CHECKING:
 
 
 class Haskell(Language):
+    def __init__(self, config: Optional["GlobalConfig"]):
+        super().__init__(config)
+        self.clean_types_regex = re.compile(r"\(([^:\s]*)\s*::\s*([A-Z][a-zA-Z0-9]*)\)")
+
     def initial_dependencies(self) -> list[str]:
         return ["Values.hs", "EvaluationUtils.hs"]
 
@@ -111,7 +115,7 @@ class Haskell(Language):
         return linter.run_hlint(self.config.dodona, remaining)
 
     def cleanup_description(self, statement: str) -> str:
-        return cleanup_description(self, statement)
+        return cleanup_description(self, self.clean_types_regex.sub(r'\1', statement))
 
     def cleanup_stacktrace(self, stacktrace: str) -> str:
         filename = submission_file(self)
@@ -165,10 +169,12 @@ class Haskell(Language):
     def generate_statement(self, statement: Statement) -> str:
         from tested.languages.haskell import generators
 
-        return generators.convert_statement(statement)
+        return self.clean_types_regex.sub(r'\1', generators.convert_statement(statement))
 
     def generate_execution_unit(self, execution_unit: "PreparedExecutionUnit") -> str:
         from tested.languages.haskell import generators
+
+        print(generators.convert_execution_unit(execution_unit))
 
         return generators.convert_execution_unit(execution_unit)
 

--- a/tested/languages/haskell/config.py
+++ b/tested/languages/haskell/config.py
@@ -79,6 +79,7 @@ class Haskell(Language):
             Construct.ASSIGNMENTS,
             Construct.EVALUATION,
             Construct.GLOBAL_VARIABLES,
+            Construct.HETEROGENEOUS_ARGUMENTS
         }
 
     def compilation(self, files: list[str]) -> CallbackResult:

--- a/tested/languages/haskell/generators.py
+++ b/tested/languages/haskell/generators.py
@@ -40,7 +40,6 @@ from tested.utils import is_statement_strict
 def convert_arguments(arguments: list[Expression]) -> str:
     return ", ".join(convert_statement(arg) for arg in arguments)
 
-
 def convert_value(value: Value) -> str:
     # Handle some advanced types.
     if value.type == AdvancedSequenceTypes.TUPLE:
@@ -48,37 +47,37 @@ def convert_value(value: Value) -> str:
         return f"({convert_arguments(value.data)})"
     elif isinstance(value.type, AdvancedNumericTypes):
         if not isinstance(value.data, SpecialNumbers):
-            return f"{value.data} :: {convert_declaration(value.type)}"
+            return f"({value.data} :: {convert_declaration(value.type)})"
         elif value.data == SpecialNumbers.NOT_A_NUMBER:
-            return f"(0/0) :: {convert_declaration(value.type)}"
+            return f"((0/0) :: {convert_declaration(value.type)})"
         elif value.data == SpecialNumbers.POS_INFINITY:
-            return f"(1/0) :: {convert_declaration(value.type)}"
+            return f"((1/0) :: {convert_declaration(value.type)})"
         else:
             assert value.data == SpecialNumbers.NEG_INFINITY
-            return f"(-1/0) :: {convert_declaration(value.type)}"
+            return f"((-1/0) :: {convert_declaration(value.type)})"
     elif value.type == AdvancedStringTypes.CHAR:
         assert isinstance(value, StringType)
         return "'" + value.data.replace("'", "\\'") + "'"
     # Handle basic types
     value = as_basic_type(value)
     if value.type == BasicNumericTypes.INTEGER:
-        return f"{value.data} :: Int"
+        return f"({value.data} :: Int)"
     elif value.type == BasicNumericTypes.REAL:
         if not isinstance(value.data, SpecialNumbers):
-            return f"{value.data} :: Double"
+            return f"({value.data} :: Double)"
         elif value.data == SpecialNumbers.NOT_A_NUMBER:
-            return "(0/0) :: Double"
+            return "((0/0) :: Double)"
         elif value.data == SpecialNumbers.POS_INFINITY:
-            return "(1/0) :: Double"
+            return "((1/0) :: Double)"
         else:
             assert SpecialNumbers.NEG_INFINITY
-            return "(-1/0) :: Double"
+            return "((-1/0) :: Double)"
     elif value.type == BasicStringTypes.TEXT:
         return json.dumps(value.data)
     elif value.type == BasicBooleanTypes.BOOLEAN:
         return str(value.data)
     elif value.type == BasicNothingTypes.NOTHING:
-        return "Nothing :: Maybe Integer"
+        return "(Nothing :: Maybe Integer)"
     elif value.type == BasicSequenceTypes.SEQUENCE:
         assert isinstance(value, SequenceType)
         return f"[{convert_arguments(value.data)}]"

--- a/tested/manual.py
+++ b/tested/manual.py
@@ -13,7 +13,7 @@ from tested.configs import DodonaConfig, Options
 from tested.main import run
 from tested.testsuite import SupportedLanguage
 
-exercise_dir = "/home/niko/Ontwikkeling/universal-judge/tests/exercises/echo-function"
+exercise_dir = "/Users/tibvdm/PycharmProjects/universal-judge/tests/exercises/haskell"
 
 
 def read_config() -> DodonaConfig:
@@ -24,10 +24,10 @@ def read_config() -> DodonaConfig:
         programming_language=SupportedLanguage("haskell"),
         natural_language="nl",
         resources=Path(exercise_dir, "evaluation"),
-        source=Path(exercise_dir, "solution/correct.hs"),
+        source=Path(exercise_dir, "solution/voorlaatste.hs"),
         judge=Path("."),
         workdir=Path("workdir"),
-        test_suite="two-specific.tson",
+        test_suite="voorlaatste.yaml",
         options=Options(
             linter=False,
         ),

--- a/tested/manual.py
+++ b/tested/manual.py
@@ -24,10 +24,10 @@ def read_config() -> DodonaConfig:
         programming_language=SupportedLanguage("haskell"),
         natural_language="nl",
         resources=Path(exercise_dir, "evaluation"),
-        source=Path(exercise_dir, "solution/voorlaatste.hs"),
+        source=Path(exercise_dir, "solution/ndeElement.hs"),
         judge=Path("."),
         workdir=Path("workdir"),
-        test_suite="voorlaatste.yaml",
+        test_suite="ndeElement.yaml",
         options=Options(
             linter=False,
         ),

--- a/tests/exercises/haskell/evaluation/ndeElement.yaml
+++ b/tests/exercises/haskell/evaluation/ndeElement.yaml
@@ -1,0 +1,16 @@
+tabs:
+  - tab: geefNde
+    testcases:
+      - expression: geefNde(0, [1, 2, 3, 4])
+        description:
+          description: geefNde 0 [1, 2, 3, 4]
+          format: haskell
+        return: 1
+      - expression: geefNde(0, [1.0, 2.0, 3.0, 4.0])
+        return: 1.0
+      - expression: geefNde(0, ['a', 'b', 'c', 'd'])
+        return: a
+      - expression: geefNde(1, [(1, 2), (3, 4), (5, 6), (7, 8)])
+        return: !tuple [3, 4]
+      - expression: geefNde(1, [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0)])
+        return: !tuple [3.0, 4.0]

--- a/tests/exercises/haskell/evaluation/voorlaatste.yaml
+++ b/tests/exercises/haskell/evaluation/voorlaatste.yaml
@@ -1,0 +1,43 @@
+tabs:
+  - tab: 'voorlaatste (Int)'
+    testcases:
+      - expression: voorlaatste([1, 2])
+        return: 1
+      - expression: voorlaatste([1, 2, 3])
+        return: 2
+      - expression: voorlaatste([1, 2, 3, 4])
+        return: 3
+      - expression: voorlaatste([1, 2, 3, 4, 5])
+        return: 4
+      - expression: voorlaatste([1, 0, 1, 0, 1])
+        return: 0
+      - expression: voorlaatste([9, 81, 1, 2, 4, 1, 42, 1])
+        return: 42
+  - tab: 'voorlaatste (Double)'
+    testcases:
+      - expression: voorlaatste([1.0, 2.0])
+        return: 1.0
+      - expression: voorlaatste([1.0, 2.0, 3.0])
+        return: 2.0
+      - expression: voorlaatste([1.0, 2.0, 3.0, 4.0])
+        return: 3.0
+      - expression: voorlaatste([1.0, 2.0, 3.0, 4.0, 5.0])
+        return: 4.0
+      - expression: voorlaatste([1.0, 0.0, 1.0, 0.0, 1.0])
+        return: 0.0
+      - expression: voorlaatste([9.0, 81.0, 1.0, 2.0, 4.0, 1.0, 42.0, 1.0])
+        return: 42.0
+  - tab: 'voorlaatste (Char)'
+    testcases:
+      - expression: voorlaatste(['a', 'b'])
+        return: 'a'
+      - expression: voorlaatste(['a', 'b', 'c'])
+        return: 'b'
+      - expression: voorlaatste(['a', 'b', 'c', 'd'])
+        return: 'c'
+      - expression: voorlaatste(['a', 'b', 'c', 'd', 'e'])
+        return: 'd'
+      - expression: voorlaatste(['a', 'b', 'a', 'b', 'a'])
+        return: 'b'
+      - expression: voorlaatste(['c', 'd', 'a', 'b', 'g'])
+        return: 'b'

--- a/tests/exercises/haskell/solution/ndeElement.hs
+++ b/tests/exercises/haskell/solution/ndeElement.hs
@@ -1,0 +1,2 @@
+geefNde :: Int -> [a] -> a
+geefNde n l = l !! n

--- a/tests/exercises/haskell/solution/voorlaatste.hs
+++ b/tests/exercises/haskell/solution/voorlaatste.hs
@@ -1,0 +1,2 @@
+voorlaatste :: [a] -> a
+voorlaatste = last . init


### PR DESCRIPTION
This pull requests:
- Enables Heterogenous arguments for the Haskell language. Explicit typing in combination with ambiguous types, enables this future. This also allows for test plans using multiple types for the same function.
- Adds parentheses around explicit typings. This fixes an issue where invalid syntax was generated due to this explicit typing (see issue #541, which is also solved by this PR)
- Remove the explicit typing from the Dodona feedback, offering a clearer output to the user.