### PR TITLE
Allow running tests on external forks after labeling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: CI
 
-on: [ push ]
+on: 
+  push:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   test:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,6 +21,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./result/coverage.xml
   lint:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +31,7 @@ jobs:
       - run: nix develop .#format -c poetry run isort --check-only ./tested ./tests
       - run: nix develop .#format -c poetry run black --check ./tested ./tests
   types:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,12 @@ on:
       - '**/*.txt'
   schedule:
     - cron: "18 21 2 * *"
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   analyze:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,9 @@
 name: Integration tests
 
-on: [ pull_request ]
+on: 
+  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 env:
   EXERCISES_COMMIT: 31ef0f174efaeba2a37415115e7fd0332573d9b2
@@ -9,6 +12,7 @@ jobs:
   # Runs the test suite in a slightly modified Docker image used by Dodona.
   # This is the closest to actually running the production environment there is.
   tests-dodona:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run ci') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +22,7 @@ jobs:
         name: Run tests in Dodona Docker image
   # Runs in the Docker image to check if the JS exercises still work.
   javascript-dodona:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run ci') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +41,7 @@ jobs:
         name: Run integration tests in Dodona Docker image
   # Runs in the repo to check if the JS exercises still work.
   javascript-repository:
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run ci') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
   # Runs the test suite in a slightly modified Docker image used by Dodona.
   # This is the closest to actually running the production environment there is.
   tests-dodona:
-    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run ci') }}
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
         name: Run tests in Dodona Docker image
   # Runs in the Docker image to check if the JS exercises still work.
   javascript-dodona:
-    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run ci') }}
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
         name: Run integration tests in Dodona Docker image
   # Runs in the repo to check if the JS exercises still work.
   javascript-repository:
-    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run ci') }}
+    if: ${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'run tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This allows adding a label to run tests on external pull requests.

This could be a security risks, so only run tests after reviewing the code.

see https://stackoverflow.com/questions/76952023/how-to-make-github-actions-safely-access-secrets-for-prs-created-from-forks