### PR TITLE
Correctl generate multiple CLI arguments for Haskell

### DIFF
--- a/tested/languages/haskell/generators.py
+++ b/tested/languages/haskell/generators.py
@@ -241,7 +241,7 @@ handleException (Right _) = Nothing
             if tc.testcase.is_main_testcase():
                 assert isinstance(tc.input, MainInput)
                 wrapped = [json.dumps(a) for a in tc.input.arguments]
-                result += indent + f"let mainArgs = [{' '.join(wrapped)}]\n"
+                result += indent + f"let mainArgs = [{' ,'.join(wrapped)}]\n"
                 result += (
                     indent
                     + f"result <- try (withArgs mainArgs {pu.submission_name}.main) :: IO (Either SomeException ())\n"

--- a/tests/exercises/dedup/evaluation/plan.yaml
+++ b/tests/exercises/dedup/evaluation/plan.yaml
@@ -1,0 +1,9 @@
+- tab: "command_line_arguments"
+  testcases:
+  - arguments: [haskell, rust, java, haskell, c, rust]
+    stdout: "c haskell java rust"
+  - arguments: ["banana", "apple", "apple", "orange", "apple", "apple", "banana", "orange"]
+    stdout: "apple banana orange"
+  - arguments: []
+    stdout: "\n"
+  

--- a/tests/exercises/dedup/solution/solution.hs
+++ b/tests/exercises/dedup/solution/solution.hs
@@ -1,0 +1,8 @@
+import Data.List (nub, sort)
+import System.Environment (getArgs)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let uniqueSorted = nub (sort args)
+  putStrLn (unwords uniqueSorted)

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tested.datatypes import (
+    AdvancedNothingTypes,
+    AdvancedSequenceTypes,
+    BasicNumericTypes,
+)
+from tested.serialisation import NothingType, NumberType, SequenceType
+from tested.utils import sorted_no_duplicates, sorting_value_extract
+from tests.manual_utils import assert_valid_output, configuration, execute_config
+
+
+@pytest.mark.parametrize("language", ["haskell"])
+def test_cli_params(
+    language: str, tmp_path: Path, pytestconfig: pytest.Config
+):
+    conf = configuration(
+        pytestconfig,
+        "dedup",
+        language,
+        tmp_path,
+        "plan.yaml",
+        "solution",
+    )
+    result = execute_config(conf)
+    print(result)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct", "correct", "correct"]


### PR DESCRIPTION
There was a bug with the Haskell judge where the list that contains the command line arguments was not correctly compiled into Haskell, due to a missing comma in the generated output.

## Example Testcase
```yaml
- tab: "command_line_arguments"
  testcases:
  - arguments: ["banana", "apple", "apple", "orange", "apple", "apple", "banana", "orange"]
    stdout: "apple banana orange"
```

The following line is responsible for converting it to Haskell:

https://github.com/dodona-edu/universal-judge/blob/3b6530439eb79d009c12b158a9f9520a159c70ef/tested/languages/haskell/generators.py#L244

However, this generates something like this:

```hs
let mainArgs = ["banana" "apple" "apple" "orange" "apple" "apple" "banana" "orange"]
```

This causes an error like this:

```
Execution0.hs:64:21: error: [GHC-83865]
    • Couldn't match expected type: String
                                    -> String -> String -> String -> String -> String -> String -> a
                  with actual type: [Char]
    • The function ‘"banana"’ is applied to 7 value arguments,
        but its type ‘[Char]’ has none
      In the expression:
        "banana" "apple" "apple" "orange" "apple" "apple" "banana" "orange"
      In the expression:
        ["banana"
           "apple" "apple" "orange" "apple" "apple" "banana" "orange"]
```

In Haskell, arrays are comma separated. This PR adds the commas, as well as a test-case for it.