### PR TITLE
Fix global definition of programming language

### DIFF
--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -187,12 +187,18 @@ def is_expression(_checker: TypeChecker, instance: Any) -> bool:
     return isinstance(instance, ExpressionString)
 
 
-def load_schema_validator(dsl_object: YamlObject = None, file: str = "schema-strict.json") -> Validator:
+def load_schema_validator(
+    dsl_object: YamlObject = None, file: str = "schema-strict.json"
+) -> Validator:
     """
     Load the JSON Schema validator used to check DSL test suites.
     """
     # if the programming language is set in the root, tested_dsl_expressions don't need to be parseable
-    language_present =  dsl_object is not None and "language" in dsl_object
+    language_present = (
+        dsl_object is not None
+        and isinstance(dsl_object, dict)
+        and "language" in dsl_object
+    )
 
     def validate_tested_dsl_expression(value: object) -> bool:
         if not isinstance(value, str):
@@ -213,7 +219,9 @@ def load_schema_validator(dsl_object: YamlObject = None, file: str = "schema-str
         "oracle", is_oracle
     ).redefine("expression", is_expression)
     format_checker = original_validator.FORMAT_CHECKER
-    format_checker.checks("tested-dsl-expression", SyntaxError)(validate_tested_dsl_expression)
+    format_checker.checks("tested-dsl-expression", SyntaxError)(
+        validate_tested_dsl_expression
+    )
     tested_validator = extend_validator(original_validator, type_checker=type_checker)
     return tested_validator(schema_object, format_checker=format_checker)
 

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -1303,6 +1303,27 @@ def test_empty_text_data_newlines():
     actual_stderr = suite.tabs[0].contexts[0].testcases[0].output.stderr.data
     assert actual_stderr == ""
 
+def test_programming_language_can_be_globally_configured():
+    yaml_str = """
+namespace: "Numbers"
+language: "java"
+tabs:
+  - tab: "Numbers.oddValues"
+    testcases:
+      - expression: "Numbers.oddValues(new int[]{1, 2, 3, 4, 5, 6, 7, 8})"
+        return: [1, 3, 5, 7]
+"""
+    json_str = translate_to_test_suite(yaml_str)
+    suite = parse_test_suite(json_str)
+    assert len(suite.tabs) == 1
+    tab = suite.tabs[0]
+    assert len(tab.contexts) == 1
+    context = tab.contexts[0]
+    assert len(context.testcases) == 1
+    testcase = context.testcases[0]
+    assert isinstance(testcase.input, LanguageLiterals)
+    assert testcase.input.type == "expression"
+    assert testcase.input.literals.keys() == {"java"}
 
 def test_strict_json_schema_is_valid():
     path_to_schema = Path(__file__).parent / "tested-draft7.json"
@@ -1316,6 +1337,6 @@ def test_strict_json_schema_is_valid():
 
 
 def test_editor_json_schema_is_valid():
-    validator = load_schema_validator("schema.json")
+    validator = load_schema_validator(file= "schema.json")
     assert isinstance(validator.schema, dict)
     validator.check_schema(validator.schema)

--- a/tests/test_dsl_yaml.py
+++ b/tests/test_dsl_yaml.py
@@ -1303,6 +1303,7 @@ def test_empty_text_data_newlines():
     actual_stderr = suite.tabs[0].contexts[0].testcases[0].output.stderr.data
     assert actual_stderr == ""
 
+
 def test_programming_language_can_be_globally_configured():
     yaml_str = """
 namespace: "Numbers"
@@ -1325,6 +1326,7 @@ tabs:
     assert testcase.input.type == "expression"
     assert testcase.input.literals.keys() == {"java"}
 
+
 def test_strict_json_schema_is_valid():
     path_to_schema = Path(__file__).parent / "tested-draft7.json"
     with open(path_to_schema, "r") as schema_file:
@@ -1337,6 +1339,6 @@ def test_strict_json_schema_is_valid():
 
 
 def test_editor_json_schema_is_valid():
-    validator = load_schema_validator(file= "schema.json")
+    validator = load_schema_validator(file="schema.json")
     assert isinstance(validator.schema, dict)
     validator.check_schema(validator.schema)


### PR DESCRIPTION
This pr disables validation of `tested-dsl-expression`  if the programming language is specified in the root.
If a programming language is specified in the root, statements and expressions are not parsed and thus don't need to match the validation.

This is a different solution than the one proposed in: https://github.com/dodona-edu/universal-judge/issues/578

The main difference is that the proposed solution told the schema that in case a programming language is specified the format is not required. While in my solution, the schema still 'requires' the format, but the validation of this format becomes more flexible in case the root language is specified.

I chose this second option as this had a way smaller impact on the code, and the validation of the format happened in custom python code anyway.

- [x] Tests are added

closes https://github.com/dodona-edu/universal-judge/issues/578