### PR TITLE
Performance: replace custom sort by native sort

### DIFF
--- a/tested/utils.py
+++ b/tested/utils.py
@@ -258,7 +258,6 @@ def sorted_no_duplicates(
         if order(key_v, last_key_val) != 0:
             no_dup.append(v)
             last_key_val = key_v
-            last_v = v
 
     return no_dup
 


### PR DESCRIPTION
This pull request replaces the custom sort in utils.py by the built-in sort with `cmp_to_key`. There's a slight difference in output: the new version is stable whereas the original was not. All tests still pass.

In addition, I fixed a small bug in order fallback.

Performance of the function itself is ~50% better. When profiling the function in an actual exercise, the improvement was closer to 30%. Probably because it is then often called on (very) small lists. For exercises using sets, the impact is more noticable.

Next to the performance benefic,  this simplifies the code.