### PR TITLE
Performance: don't use f-strings in debug prints

### DIFF
--- a/tested/configs.py
+++ b/tested/configs.py
@@ -190,14 +190,16 @@ def _get_language(config: DodonaConfig) -> tuple[SupportedLanguage, int]:
     bang = _consume_shebang(config.source)
     if bang and langs.language_exists(bang):
         _logger.debug(
-            f"Found shebang language and it exists, using {bang} instead "
-            f"of config language {config.programming_language}."
+            "Found shebang language and it exists, using %s instead of config language %s.",
+            bang,
+            config.programming_language,
         )
         return bang, 1
     else:
         _logger.debug(
-            f"No shebang found or it doesn't exist: {bang}. Using "
-            f"configuration language {config.programming_language}."
+            "No shebang found or it doesn't exist: %s. Using configuration language %s.",
+            bang,
+            config.programming_language,
         )
         return config.programming_language, 0
 

--- a/tested/internationalization/__init__.py
+++ b/tested/internationalization/__init__.py
@@ -14,7 +14,7 @@ i18n.load_path.append(os.path.dirname(__file__))
 
 
 def set_locale(locale: str):
-    _logger.debug(f"Change locale to {locale}")
+    _logger.debug("Change locale to %s", locale)
     i18n.set("locale", locale)
 
 

--- a/tested/judge/collector.py
+++ b/tested/judge/collector.py
@@ -67,8 +67,8 @@ class OutputManager:
         """
         assert not self.finalized, "OutputManager already finished!"
         action, type_ = command.command.split("-")
-        _logger.debug(f"Adding {command}")
-        _logger.debug(f"Stack is {self.open_stack}")
+        _logger.debug("Adding %s", command)
+        _logger.debug("Stack is %s", self.open_stack)
         if action == "start":
             self.open_stack.append(type_)
         elif action == "close":
@@ -86,7 +86,7 @@ class OutputManager:
                 tabs, contexts, _ = self.currently_open
                 self.currently_open = (tabs, contexts, index + 1)
 
-        _logger.debug(f"After adding, stack is {self.open_stack}")
+        _logger.debug("After adding, stack is %s", self.open_stack)
         report_update(self.out, command)
 
     def terminate(

--- a/tested/judge/compilation.py
+++ b/tested/judge/compilation.py
@@ -64,7 +64,7 @@ def run_compilation(
         "Generating files with command %s in directory %s", command, directory
     )
     result = run_command(directory, remaining, command)
-    _logger.debug(f"Compilation dependencies are: {files}")
+    _logger.debug("Compilation dependencies are: %s", files)
     return result, files
 
 

--- a/tested/judge/core.py
+++ b/tested/judge/core.py
@@ -171,7 +171,7 @@ def judge(bundle: Bundle):
     else:
         max_workers = 1
 
-    _logger.debug(f"Executing with {max_workers} workers")
+    _logger.debug("Executing with %s workers", max_workers)
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         remaining_time = plan.remaining_time()
@@ -186,7 +186,7 @@ def judge(bundle: Bundle):
                 execution_dir,
             ) in enumerate(results):
                 planned_unit = plan.units[i]
-                _logger.debug(f"Processing results for execution unit {i}")
+                _logger.debug("Processing results for execution unit %s", i)
                 result_status, currently_open_tab = _process_results(
                     bundle=bundle,
                     unit=planned_unit,
@@ -259,7 +259,7 @@ def _generate_files(
     common_dir = Path(bundle.config.workdir, f"common")
     common_dir.mkdir()
 
-    _logger.debug(f"Generating files in common directory {common_dir}")
+    _logger.debug("Generating files in common directory %s", common_dir)
 
     # Copy dependencies
     dependency_paths = bundle.language.path_to_dependencies()
@@ -278,7 +278,7 @@ def _generate_files(
     execution_names = []
     # Generate the files for each execution.
     for execution_unit in execution_plan:
-        _logger.debug(f"Generating file for execution {execution_unit.name}")
+        _logger.debug("Generating file for execution %s", execution_unit.name)
         generated, evaluators = generate_execution(
             bundle=bundle, destination=common_dir, execution_unit=execution_unit
         )
@@ -286,7 +286,7 @@ def _generate_files(
         # Copy functions to the directory.
         for evaluator in evaluators:
             source = Path(bundle.config.resources) / evaluator
-            _logger.debug(f"Copying oracle from {source} to {common_dir}")
+            _logger.debug("Copying oracle from %s to %s", source, common_dir)
             shutil.copy2(source, common_dir)
 
         dependencies.extend(evaluators)

--- a/tested/judge/evaluation.py
+++ b/tested/judge/evaluation.py
@@ -246,7 +246,7 @@ def evaluate_context_results(
 
     # Begin processing the normal testcases.
     for i, testcase in enumerate(context.testcases):
-        _logger.debug(f"Evaluating testcase {i}")
+        _logger.debug("Evaluating testcase %s", i)
 
         readable_input, seen = get_readable_input(bundle, testcase)
         all_files = all_files - seen

--- a/tested/judge/execution.py
+++ b/tested/judge/execution.py
@@ -133,7 +133,7 @@ def execute_file(
         file=executable_name,
         arguments=[argument] if argument else [],
     )
-    _logger.debug(f"Executing {command} in directory {working_directory}")
+    _logger.debug("Executing %s in directory %s", command, working_directory)
 
     result = run_command(working_directory, remaining, command, stdin)
 
@@ -163,7 +163,7 @@ def set_up_unit(
     # Filter dependencies of the global compilation results.
     dependencies = filter_files(plan.files, plan.common_directory)
     dependencies = bundle.language.filter_dependencies(dependencies, unit.name)
-    _logger.debug(f"Dependencies are {dependencies}")
+    _logger.debug("Dependencies are %s", dependencies)
     copy_workdir_files(bundle, execution_dir, True)
 
     # Copy files from the common directory to the context directory.
@@ -172,7 +172,7 @@ def set_up_unit(
         destination = execution_dir / file
         # Ensure we preserve subdirectories.
         destination.parent.mkdir(parents=True, exist_ok=True)
-        _logger.debug(f"Copying {origin} to {destination}")
+        _logger.debug("Copying %s to %s", origin, destination)
         if origin == destination:
             continue  # Don't copy the file to itself
 
@@ -235,7 +235,7 @@ def execute_unit(
         argument = None
 
     executable_or_status = bundle.language.find_main_file(files, main_file_name)
-    _logger.debug(f"Searched for main file: {executable_or_status}")
+    _logger.debug("Searched for main file: %s", executable_or_status)
     if isinstance(executable_or_status, Status):
         return executable_or_status
 

--- a/tested/judge/utils.py
+++ b/tested/judge/utils.py
@@ -123,14 +123,14 @@ def copy_workdir_files(bundle: Bundle, destination: Path, all_files: bool) -> li
                 all_files or bundle.language.is_source_file(origin)
             ):
                 source_files.append(str(dst / origin.name))
-                _logger.debug(f"Copying {origin} to {dst}")
+                _logger.debug("Copying %s to %s", origin, dst)
                 shutil.copy2(origin, dst)
             elif (
                 origin.is_dir()
                 and not file.startswith(EXECUTION_PREFIX)
                 and file != "common"
             ):
-                _logger.debug(f"Iterate subdir {dst / file}")
+                _logger.debug("Iterate subdir %s", dst / file)
                 shutil.copytree(origin, dst / file)
 
     recursive_copy(bundle.config.workdir, destination)

--- a/tested/oracles/programmed.py
+++ b/tested/oracles/programmed.py
@@ -219,7 +219,7 @@ def evaluate(
     assert isinstance(channel, OracleOutputChannel)
     assert isinstance(channel.oracle, CustomCheckOracle)
 
-    _logger.debug(f"Programmed oracle for output {actual_str}")
+    _logger.debug("Programmed oracle for output %s", actual_str)
 
     # Convert the expected item to a Value, which is then passed to the
     # oracle for evaluation.
@@ -241,9 +241,9 @@ def evaluate(
         )
 
     _logger.debug(
-        f"Calling programmed evaluation with params:\n"
-        f"expected: {expected}\n"
-        f"actual: {actual}"
+        "Calling programmed evaluation with params:\nexpected: %s\nactual: %s",
+        expected,
+        actual,
     )
     context = OracleContext(
         expected=expected,

--- a/tested/parsing.py
+++ b/tested/parsing.py
@@ -38,12 +38,12 @@ def unstructure_decimal(obj: Decimal) -> str:
 def structure_every_union(to_convert: Any, the_type: type) -> Any:
     from tested.serialisation import Identifier
 
-    _logger.debug(f"=== Finding type for {to_convert}, from {the_type}...")
+    _logger.debug("=== Finding type for %s, from %s...", to_convert, the_type)
     if to_convert is None and type(None) in get_args(the_type):
         _logger.debug("Yes: found None.")
         return None
     if isinstance(to_convert, bool) and bool in get_args(the_type):
-        _logger.debug(f"Yes: found boolean: {to_convert}.")
+        _logger.debug("Yes: found boolean: %s.", to_convert)
         return to_convert
 
     for possible_class in get_args(the_type):
@@ -61,10 +61,10 @@ def structure_every_union(to_convert: Any, the_type: type) -> Any:
             if possible_class is Identifier:
                 assert isinstance(to_convert, str)
             result = _suite_converter.structure(to_convert, possible_class)
-            _logger.debug(f"{debug_message} accepted.")
+            _logger.debug("%s accepted.", debug_message)
             return result
         except Exception:
-            _logger.debug(f"{debug_message} rejected.")
+            _logger.debug("%s rejected.", debug_message)
     raise TypeError(
         f"{to_convert} could not be converted into a {the_type}. Check the syntax or file a bug."
     )


### PR DESCRIPTION
Many of the debug prints contained f-strings. While these are easy to read, the string is created even if the logger never needs the actual string because of the debug level. Switching to lazy string formatting saves some work and garbage collection if debugging is not enabled.

Unexpectedly, performance gains are measurable and up to 5% when measuring the total run time of a single exercise (21.6s -> 20.5s, average over 10 runs).