### PR TITLE
Raise default memory limit for TESTed exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
     "judge": "TESTed",
-    "image": "dodona-tested"
+    "image": "dodona-tested",
+    "memory_limit": 500000000
 }


### PR DESCRIPTION
We're sometimes seeing internal errors for compiled languages if this memory limit isn't high enough. Times the default by 5 to hopefully prevent this.