### PR TITLE
Ignore cyclic imports in CodeQL

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -2,3 +2,6 @@ paths:
   - tested
 paths-ignore:
   - tested/languages
+query-filters:
+  - exclude:
+      id: py/unsafe-cyclic-import


### PR DESCRIPTION
These keep popping up and are mostly false positives (the tests should catch real instances that cause problems)