### PR TITLE
Add pandas 3.0.1 and openpyxl 3.1.5 as Python exercise dependencies

### DIFF
--- a/.devcontainer/dodona-tested.dockerfile
+++ b/.devcontainer/dodona-tested.dockerfile
@@ -108,7 +108,9 @@ RUN <<EOF
 
     # Exercise dependencies
     pip install --no-cache-dir --upgrade \
-      numpy==2.3.5
+      numpy==2.3.5 \
+      pandas==3.0.1 \
+      openpyxl==3.1.5
 
     # Clean up caches
     apt-get clean


### PR DESCRIPTION
This PR adds pandas 3.0.1 and openpyxl 3.1.5 as Python exercise dependencies as requested. It also aligns the dockerfile with the current version in the docker-images repo.

It changes the image size from 5.97GB to 6.08GB (110MB). 

Manual testing:
- Build it
- Spin it up
- Verify you can import both `pandas` (`import pandas`) and `openpyxl` (`from openpyxl import Workbook`)

When merged, a PR will be created in docker-images to update the dockerfile over there.