### PR TITLE
File follow ups

### DIFF
--- a/tested/dsl/translate_parser.py
+++ b/tested/dsl/translate_parser.py
@@ -694,9 +694,11 @@ def _convert_testcase(testcase: YamlDict, context: DslContext) -> Testcase:
         the_input = MainInput(stdin=stdin, arguments=arguments)
         return_channel = None
 
+    use_strict_workdir = False
     if "input_files" in testcase:
         assert isinstance(testcase["input_files"], list)
 
+        use_strict_workdir = True
         input_files = []
         for file_object in testcase["input_files"]:
             input_files.append(_convert_text_data_required_path(file_object))
@@ -771,6 +773,7 @@ def _convert_testcase(testcase: YamlDict, context: DslContext) -> Testcase:
         output=output,
         input_files=input_files,
         line_comment=line_comment,
+        use_strict_workdir=use_strict_workdir,
     )
 
 

--- a/tested/judge/execution.py
+++ b/tested/judge/execution.py
@@ -166,7 +166,13 @@ def set_up_unit(
     dependencies = filter_files(plan.files, plan.common_directory)
     dependencies = bundle.language.filter_dependencies(dependencies, unit.name)
     _logger.debug("Dependencies are %s", dependencies)
-    copy_workdir_files(bundle, execution_dir, True)
+
+    # When using a strict workdir, only the files listed in the "input_files"
+    # are available in the workdir for the execution unit.
+    # If that is the case, the "dynamic" files below will copy/generate
+    # all necessary files.
+    if not unit.has_strict_workdir():
+        copy_workdir_files(bundle, execution_dir, True)
 
     # Copy files from the common directory to the context directory.
     for file in dependencies:

--- a/tested/judge/planning.py
+++ b/tested/judge/planning.py
@@ -62,27 +62,18 @@ class PlannedExecutionUnit:
     def has_exit_testcase(self) -> bool:
         return self.contexts[-1].context.has_exit_testcase()
 
+    def has_strict_workdir(self) -> bool:
+        return any(context.context.has_strict_workdir() for context in self.contexts)
+
     def get_dynamically_generated_files(self) -> list[DynamicallyGeneratedFile]:
         generated_files = set()
+        uses_strict_workdir = self.has_strict_workdir()
 
         for context in self.contexts:
             for testcase in context.context.testcases:
-                if (
-                    isinstance(testcase.input, MainInput)
-                    and testcase.input.stdin != EmptyChannel.NONE
-                    and testcase.input.stdin.is_dynamically_generated()
-                    and testcase.input.stdin.path is not None
-                ):
-                    generated_files.add(
-                        DynamicallyGeneratedFile(
-                            path=testcase.input.stdin.path,
-                            content=testcase.input.stdin.content,
-                        )
-                    )
-
                 for input_file in testcase.input_files:
                     if (
-                        input_file.is_dynamically_generated()
+                        (uses_strict_workdir or input_file.is_dynamically_generated())
                         and input_file.path is not None
                     ):
                         generated_files.add(
@@ -141,10 +132,12 @@ def _flattened_contexts_to_units(
     current_output_files: set[str] = set()  # These are paths
 
     for planned in flattened_contexts:
+        strict = planned.context.has_strict_workdir()
+
         planned_input_files = {
-            planned_input_file.path: planned_input_file.content
-            for planned_input_file in planned.context.get_input_files()
-            if planned_input_file.path
+            f.path: f.content
+            for f in planned.context.get_input_files()
+            if f.path and (strict or f.is_dynamically_generated())
         }
 
         planned_output_files = [
@@ -154,10 +147,7 @@ def _flattened_contexts_to_units(
         ]
 
         # If any context wants the same input file with different content, we have a conflict.
-        has_input_file_conflict = any(
-            path in current_input_files and current_input_files[path] != content
-            for path, content in planned_input_files.items()
-        )
+        has_input_file_conflict = planned_input_files != current_input_files
 
         # If any context wants an output file in the same location, we have a conflict.
         has_output_conflict = any(

--- a/tested/judge/planning.py
+++ b/tested/judge/planning.py
@@ -73,9 +73,8 @@ class PlannedExecutionUnit:
             for testcase in context.context.testcases:
                 for input_file in testcase.input_files:
                     if (
-                        (uses_strict_workdir or input_file.is_dynamically_generated())
-                        and input_file.path is not None
-                    ):
+                        uses_strict_workdir or input_file.is_dynamically_generated()
+                    ) and input_file.path is not None:
                         generated_files.add(
                             DynamicallyGeneratedFile(
                                 path=input_file.path,

--- a/tested/judge/planning.py
+++ b/tested/judge/planning.py
@@ -145,6 +145,12 @@ def _flattened_contexts_to_units(
             if planned_output_file.path
         ]
 
+        current_unit_is_strict = any(
+            c.context.has_strict_workdir() for c in current_unit_contexts
+        )
+        # If this unit is strict but the others not, or the other way around, also start a new context.
+        has_strictness_conflict = strict != current_unit_is_strict
+
         # If any context wants the same input file with different content, we have a conflict.
         has_input_file_conflict = planned_input_files != current_input_files
 
@@ -160,7 +166,12 @@ def _flattened_contexts_to_units(
             != EmptyChannel.NONE
         )
 
-        if has_input_file_conflict or has_stdin_conflict or has_output_conflict:
+        if (
+            has_strictness_conflict
+            or has_input_file_conflict
+            or has_stdin_conflict
+            or has_output_conflict
+        ):
             if current_unit_contexts:
                 contexts_per_unit.append(current_unit_contexts)
             current_unit_contexts = []

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -141,7 +141,7 @@ def get_readable_input(
             text = f"{args} < {stdin}"
         elif case.input.arguments and stdin:
             assert stdin[-1] == "\n", "stdin must end with a newline"
-            if stdin.count('\n') == 1:
+            if stdin.count("\n") == 1:
                 text = f"{args} <<< {stdin}"
             else:
                 delimiter = _get_heredoc_token(stdin)

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -141,8 +141,11 @@ def get_readable_input(
             text = f"{args} < {stdin}"
         elif case.input.arguments and stdin:
             assert stdin[-1] == "\n", "stdin must end with a newline"
-            delimiter = _get_heredoc_token(stdin)
-            text = f"{args} << '{delimiter}'\n{stdin}{delimiter}"
+            if stdin.count('\n') == 1:
+                text = f"{args} <<< {stdin}"
+            else:
+                delimiter = _get_heredoc_token(stdin)
+                text = f"{args} << '{delimiter}'\n{stdin}{delimiter}"
         elif stdin:
             assert not case.input.arguments
             text = stdin

--- a/tested/testsuite.py
+++ b/tested/testsuite.py
@@ -626,6 +626,8 @@ class Testcase(WithFeatures, WithFunctions):
     description: Message | None = None
     output: Output = field(factory=Output)
     input_files: list[TextData] = field(factory=list)
+    # If true, only "input_files" will be available in the workdir.
+    use_strict_workdir: bool = False
     line_comment: str = ""
 
     def get_used_features(self) -> FeatureSet:
@@ -773,6 +775,9 @@ class Context(WithFeatures, WithFunctions):
             if isinstance(t.output.file, FileOutputChannel):
                 all_files.update(t.output.file.files)
         return all_files
+
+    def has_strict_workdir(self) -> bool:
+        return any(testcase.use_strict_workdir for testcase in self.testcases)
 
 
 def _runs_to_tab_converter(runs: list | None, _):

--- a/tests/exercises/echo/evaluation/plan-lax-workdir.yaml
+++ b/tests/exercises/echo/evaluation/plan-lax-workdir.yaml
@@ -1,0 +1,3 @@
+- tab: "Tests"
+  testcases:
+    - stdout: "workdir content"

--- a/tests/exercises/echo/evaluation/plan-stdin-multiline-args.yaml
+++ b/tests/exercises/echo/evaluation/plan-stdin-multiline-args.yaml
@@ -1,0 +1,7 @@
+- tab: "Tests"
+  testcases:
+    - stdin: |
+        Line1
+        Line2
+      arguments: ["arg1"]
+      stdout: "Line1"

--- a/tests/exercises/echo/evaluation/plan-strict-isolation.yaml
+++ b/tests/exercises/echo/evaluation/plan-strict-isolation.yaml
@@ -1,0 +1,6 @@
+- tab: "Tests"
+  testcases:
+    - input_files:
+        - path: "other.txt"
+          content: "not used"
+      stdout: "absent"

--- a/tests/exercises/echo/solution/correct-files-nested.py
+++ b/tests/exercises/echo/solution/correct-files-nested.py
@@ -1,2 +1,1 @@
-with open("subdir/input.txt") as f:
-    print(f.read().strip())
+print(input())

--- a/tests/exercises/echo/solution/correct-workdir.py
+++ b/tests/exercises/echo/solution/correct-workdir.py
@@ -1,0 +1,5 @@
+try:
+    with open("workdir-extra.txt") as f:
+        print(f.read().strip())
+except FileNotFoundError:
+    print("absent")

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -780,6 +780,27 @@ def test_main_call_quotes(tmp_path: Path, pytestconfig: pytest.Config):
     )
 
 
+def test_stdin_and_arguments_single_line_use_herestring(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    conf = configuration(
+        pytestconfig,
+        "echo-function",
+        "bash",
+        tmp_path,
+        "two.yaml",
+        "top-level-output",
+    )
+    the_input = Testcase(
+        input=MainInput(arguments=["hello"], stdin=TextData(content="One line\n"))
+    )
+    suite = Suite(tabs=[Tab(contexts=[Context(testcases=[the_input])], name="hallo")])
+    bundle = create_bundle(conf, sys.stdout, suite)
+    actual, _ = get_readable_input(bundle, the_input)
+
+    assert actual.description == "$ submission hello <<< One line\n"
+
+
 def test_stdin_and_arguments_use_heredoc(tmp_path: Path, pytestconfig: pytest.Config):
     conf = configuration(
         pytestconfig,

--- a/tests/test_io_exercises.py
+++ b/tests/test_io_exercises.py
@@ -63,6 +63,45 @@ def test_io_exercise_input_dynamic_file_nested_path(
     assert updates.find_status_enum() == ["correct"]
 
 
+def test_io_exercise_stdin_multiline_args(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # Exercises the heredoc display path (stdin.count('\n') > 1) in get_readable_input().
+    # Python-only: other correct.* solutions read all of stdin and would produce different output.
+    conf = configuration(
+        pytestconfig, "echo", "python", tmp_path, "plan-stdin-multiline-args.yaml", "correct"
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"]
+
+
+def test_io_exercise_lax_workdir_has_workdir_files(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    (tmp_path / "workdir-extra.txt").write_text("workdir content\n")
+    conf = configuration(
+        pytestconfig, "echo", "python", tmp_path, "plan-lax-workdir.yaml", "correct-workdir"
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"]
+
+
+def test_io_exercise_strict_workdir_isolates_workdir_files(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # workdir-extra.txt is present in the working dir, but strict mode prevents it
+    # from reaching the execution directory since it is not listed in input_files.
+    (tmp_path / "workdir-extra.txt").write_text("workdir content\n")
+    conf = configuration(
+        pytestconfig, "echo", "python", tmp_path, "plan-strict-isolation.yaml", "correct-workdir"
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["correct"]
+
+
 @pytest.mark.parametrize("language", ALL_LANGUAGES)
 def test_io_exercise_wrong(language: str, tmp_path: Path, pytestconfig: pytest.Config):
     conf = configuration(pytestconfig, "echo", language, tmp_path, "one.tson", "wrong")

--- a/tests/test_io_exercises.py
+++ b/tests/test_io_exercises.py
@@ -63,13 +63,16 @@ def test_io_exercise_input_dynamic_file_nested_path(
     assert updates.find_status_enum() == ["correct"]
 
 
-def test_io_exercise_stdin_multiline_args(
-    tmp_path: Path, pytestconfig: pytest.Config
-):
+def test_io_exercise_stdin_multiline_args(tmp_path: Path, pytestconfig: pytest.Config):
     # Exercises the heredoc display path (stdin.count('\n') > 1) in get_readable_input().
     # Python-only: other correct.* solutions read all of stdin and would produce different output.
     conf = configuration(
-        pytestconfig, "echo", "python", tmp_path, "plan-stdin-multiline-args.yaml", "correct"
+        pytestconfig,
+        "echo",
+        "python",
+        tmp_path,
+        "plan-stdin-multiline-args.yaml",
+        "correct",
     )
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
@@ -81,7 +84,12 @@ def test_io_exercise_lax_workdir_has_workdir_files(
 ):
     (tmp_path / "workdir-extra.txt").write_text("workdir content\n")
     conf = configuration(
-        pytestconfig, "echo", "python", tmp_path, "plan-lax-workdir.yaml", "correct-workdir"
+        pytestconfig,
+        "echo",
+        "python",
+        tmp_path,
+        "plan-lax-workdir.yaml",
+        "correct-workdir",
     )
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
@@ -95,7 +103,12 @@ def test_io_exercise_strict_workdir_isolates_workdir_files(
     # from reaching the execution directory since it is not listed in input_files.
     (tmp_path / "workdir-extra.txt").write_text("workdir content\n")
     conf = configuration(
-        pytestconfig, "echo", "python", tmp_path, "plan-strict-isolation.yaml", "correct-workdir"
+        pytestconfig,
+        "echo",
+        "python",
+        tmp_path,
+        "plan-strict-isolation.yaml",
+        "correct-workdir",
     )
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -11,6 +11,7 @@ from tested.judge.planning import (
     plan_test_suite,
 )
 from tested.testsuite import (
+    ContentPath,
     Context,
     EmptyChannel,
     ExitCodeOutputChannel,
@@ -479,14 +480,14 @@ def test_planning_mixed_conflicts(tmp_path: Path, pytestconfig: pytest.Config):
     bundle = create_bundle(conf, sys.stdout, suite)
     units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
 
-    assert len(units) == 3
-    assert [len(u.contexts) for u in units] == [1, 4, 1]
+    assert len(units) == 5
+    assert [len(u.contexts) for u in units] == [1, 2, 1, 1, 1]
     assert units[0].contexts[0].context == ctx1
     assert units[1].contexts[0].context == ctx2
     assert units[1].contexts[1].context == ctx3
-    assert units[1].contexts[2].context == ctx4
-    assert units[1].contexts[3].context == ctx5
-    assert units[2].contexts[0].context == ctx6
+    assert units[2].contexts[0].context == ctx4
+    assert units[3].contexts[0].context == ctx5
+    assert units[4].contexts[0].context == ctx6
 
 
 def test_planning_sequential_exit_codes(tmp_path: Path, pytestconfig: pytest.Config):
@@ -507,3 +508,183 @@ def test_planning_sequential_exit_codes(tmp_path: Path, pytestconfig: pytest.Con
     assert len(units) == 2
     assert len(units[0].contexts) == 1
     assert len(units[1].contexts) == 1
+
+
+def test_planning_conflict_input_file_forward_leak(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # ctx A has a dynamic file; ctx B has no input files.
+    # The file written for A would persist into B, so they must be split.
+    file_a = TextData(path="file.txt", content="content")
+    ctx_a = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[file_a]
+            )
+        ]
+    )
+    ctx_b = Context(
+        testcases=[SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])]
+    )
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2
+
+
+def test_planning_conflict_input_file_backward_leak(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # ctx A has no input files; ctx B has a dynamic file.
+    # Files are written upfront, so B's file would already be present during A.
+    ctx_a = Context(
+        testcases=[SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])]
+    )
+    file_b = TextData(path="file.txt", content="content")
+    ctx_b = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[file_b]
+            )
+        ]
+    )
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2
+
+
+def test_planning_no_conflict_static_input_files_lax(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # Both contexts use the same static ContentPath file in lax mode.
+    # Static files are already in the workdir, so no conflict arises.
+    static_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
+    ctx_a = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[static_file]
+            )
+        ]
+    )
+    ctx_b = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[static_file]
+            )
+        ]
+    )
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 1
+
+
+def test_planning_conflict_strict_then_lax(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # ctx A is strict (declares input_files); ctx B is lax (no input_files).
+    # Strict ctx includes static files in its footprint, so the sets differ.
+    strict_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
+    tc_a = SuiteTestcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[strict_file],
+        use_strict_workdir=True,
+    )
+    ctx_a = Context(testcases=[tc_a])
+    tc_b = SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
+    ctx_b = Context(testcases=[tc_b])
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2
+
+
+def test_planning_conflict_lax_then_strict(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # ctx A is lax; ctx B is strict. B's static file footprint differs from A's empty set.
+    tc_a = SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
+    ctx_a = Context(testcases=[tc_a])
+    strict_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
+    tc_b = SuiteTestcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[strict_file],
+        use_strict_workdir=True,
+    )
+    ctx_b = Context(testcases=[tc_b])
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2
+
+
+def test_planning_no_conflict_strict_same_files(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # Both contexts are strict with the same ContentPath file → 1 unit.
+    strict_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
+    tc = SuiteTestcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[strict_file],
+        use_strict_workdir=True,
+    )
+    ctx_a = Context(testcases=[tc])
+    ctx_b = Context(testcases=[tc])
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 1
+
+
+def test_planning_conflict_strict_different_files(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # Both contexts are strict but declare different files → 2 units.
+    file_a = TextData(path="a.txt", content=ContentPath(path="a.txt"))
+    tc_a = SuiteTestcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[file_a],
+        use_strict_workdir=True,
+    )
+    ctx_a = Context(testcases=[tc_a])
+
+    file_b = TextData(path="b.txt", content=ContentPath(path="b.txt"))
+    tc_b = SuiteTestcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[file_b],
+        use_strict_workdir=True,
+    )
+    ctx_b = Context(testcases=[tc_b])
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -524,7 +524,9 @@ def test_planning_conflict_input_file_forward_leak(
         ]
     )
     ctx_b = Context(
-        testcases=[SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])]
+        testcases=[
+            SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
+        ]
     )
 
     tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
@@ -542,7 +544,9 @@ def test_planning_conflict_input_file_backward_leak(
     # ctx A has no input files; ctx B has a dynamic file.
     # Files are written upfront, so B's file would already be present during A.
     ctx_a = Context(
-        testcases=[SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])]
+        testcases=[
+            SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
+        ]
     )
     file_b = TextData(path="file.txt", content="content")
     ctx_b = Context(
@@ -592,9 +596,7 @@ def test_planning_no_conflict_static_input_files_lax(
     assert len(units) == 1
 
 
-def test_planning_conflict_strict_then_lax(
-    tmp_path: Path, pytestconfig: pytest.Config
-):
+def test_planning_conflict_strict_then_lax(tmp_path: Path, pytestconfig: pytest.Config):
     # ctx A is strict (declares input_files); ctx B is lax (no input_files).
     # Strict ctx includes static files in its footprint, so the sets differ.
     strict_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
@@ -616,9 +618,7 @@ def test_planning_conflict_strict_then_lax(
     assert len(units) == 2
 
 
-def test_planning_conflict_lax_then_strict(
-    tmp_path: Path, pytestconfig: pytest.Config
-):
+def test_planning_conflict_lax_then_strict(tmp_path: Path, pytestconfig: pytest.Config):
     # ctx A is lax; ctx B is strict. B's static file footprint differs from A's empty set.
     tc_a = SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
     ctx_a = Context(testcases=[tc_a])

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -569,8 +569,9 @@ def test_planning_conflict_input_file_backward_leak(
 def test_planning_no_conflict_static_input_files_lax(
     tmp_path: Path, pytestconfig: pytest.Config
 ):
-    # Both contexts use the same static ContentPath file in lax mode.
-    # Static files are already in the workdir, so no conflict arises.
+    # In lax mode, static ContentPath files are excluded from the conflict footprint
+    # (is_dynamically_generated() is False), so planned_input_files == {} for both
+    # contexts and they merge into 1 unit.
     static_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
     ctx_a = Context(
         testcases=[
@@ -583,6 +584,38 @@ def test_planning_no_conflict_static_input_files_lax(
         testcases=[
             SuiteTestcase(
                 input=MainInput(stdin=EmptyChannel.NONE), input_files=[static_file]
+            )
+        ]
+    )
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 1
+
+
+def test_planning_no_conflict_lax_different_static_files(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # In lax mode, static ContentPath files are excluded from the conflict footprint
+    # regardless of which files are listed. Two lax contexts with *different* static
+    # files still merge into 1 unit.
+    file_a = TextData(path="a.txt", content=ContentPath(path="a.txt"))
+    file_b = TextData(path="b.txt", content=ContentPath(path="b.txt"))
+    ctx_a = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[file_a]
+            )
+        ]
+    )
+    ctx_b = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[file_b]
             )
         ]
     )
@@ -680,6 +713,60 @@ def test_planning_conflict_strict_different_files(
         use_strict_workdir=True,
     )
     ctx_b = Context(testcases=[tc_b])
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2
+
+
+def test_planning_conflict_strict_empty_vs_lax_empty(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # ctx A is strict with no input_files (footprint {}); ctx B is lax with no input files
+    # (also {}). File footprints are equal but strictness differs → 2 units.
+    tc_a = SuiteTestcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[],
+        use_strict_workdir=True,
+    )
+    ctx_a = Context(testcases=[tc_a])
+    tc_b = SuiteTestcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
+    ctx_b = Context(testcases=[tc_b])
+
+    tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
+    suite = Suite(tabs=[tab])
+    conf = configuration(pytestconfig, "echo-function", "python", tmp_path)
+    bundle = create_bundle(conf, sys.stdout, suite)
+    units = plan_test_suite(bundle, PlanStrategy.OPTIMAL)
+
+    assert len(units) == 2
+
+
+def test_planning_conflict_lax_different_dynamic_paths(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # ctx A has dynamic file a.txt; ctx B has dynamic file b.txt (different paths, no overlap).
+    # The equality check treats different footprints as a conflict → 2 units.
+    file_a = TextData(path="a.txt", content="content-a")
+    ctx_a = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[file_a]
+            )
+        ]
+    )
+    file_b = TextData(path="b.txt", content="content-b")
+    ctx_b = Context(
+        testcases=[
+            SuiteTestcase(
+                input=MainInput(stdin=EmptyChannel.NONE), input_files=[file_b]
+            )
+        ]
+    )
 
     tab = Tab(name="tab1", contexts=[ctx_a, ctx_b])
     suite = Suite(tabs=[tab])

--- a/tests/test_planning_sorting.py
+++ b/tests/test_planning_sorting.py
@@ -189,7 +189,9 @@ def test_get_dynamically_generated_files_not_dynamic_lax_vs_strict():
         use_strict_workdir=True,
     )
     strict_context = Context(testcases=[strict_testcase])
-    strict_planned = PlannedContext(context=strict_context, tab_index=0, context_index=0)
+    strict_planned = PlannedContext(
+        context=strict_context, tab_index=0, context_index=0
+    )
     strict_unit = PlannedExecutionUnit(
         contexts=[strict_planned], name="strict_unit", index=0
     )
@@ -209,7 +211,9 @@ def test_has_strict_workdir():
     strict_context = Context(testcases=[strict_testcase])
     lax_context = Context(testcases=[lax_testcase])
 
-    strict_planned = PlannedContext(context=strict_context, tab_index=0, context_index=0)
+    strict_planned = PlannedContext(
+        context=strict_context, tab_index=0, context_index=0
+    )
     lax_planned = PlannedContext(context=lax_context, tab_index=0, context_index=1)
 
     mixed_unit = PlannedExecutionUnit(

--- a/tests/test_planning_sorting.py
+++ b/tests/test_planning_sorting.py
@@ -11,16 +11,14 @@ from tested.testsuite import (
 )
 
 
-def test_get_dynamically_generated_files_stdin_sorting():
-    # Test sorting when files are generated from stdin
-    # We must put them in different contexts because only the first testcase
-    # in a context can have MainInput.
+def test_get_dynamically_generated_files_stdin_not_included():
+    # stdin.path is display-only ("< hello.txt" in the description).
+    # Stdin content is delivered via the process pipe, not written to disk.
     file1 = TextData(path="stdin.txt", content=ContentPath(path="url1"))
     testcase1 = Testcase(input=MainInput(stdin=file1), input_files=[])
     context1 = Context(testcases=[testcase1])
     planned_context1 = PlannedContext(context=context1, tab_index=0, context_index=0)
 
-    # Another context with same stdin path but different url
     file2 = TextData(path="stdin.txt", content=ContentPath(path="url2"))
     testcase2 = Testcase(input=MainInput(stdin=file2), input_files=[])
     context2 = Context(testcases=[testcase2])
@@ -30,12 +28,7 @@ def test_get_dynamically_generated_files_stdin_sorting():
         contexts=[planned_context1, planned_context2], name="unit0", index=0
     )
 
-    generated_files = unit.get_dynamically_generated_files()
-    assert len(generated_files) == 2
-    assert isinstance(generated_files[0].content, ContentPath)
-    assert generated_files[0].content.path == "url1"
-    assert isinstance(generated_files[1].content, ContentPath)
-    assert generated_files[1].content.path == "url2"
+    assert unit.get_dynamically_generated_files() == []
 
 
 def test_get_dynamically_generated_files_empty():
@@ -153,3 +146,78 @@ def test_get_dynamically_generated_files_none_path():
 )
 def test_is_dynamically_generated(text_data: TextData, expected: bool):
     assert text_data.is_dynamically_generated() == expected
+
+
+def test_get_dynamically_generated_files_strict_workdir_includes_static():
+    """In strict mode, static ContentPath files (path == content.path) are included."""
+    static_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
+    testcase = Testcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[static_file],
+        use_strict_workdir=True,
+    )
+    context = Context(testcases=[testcase])
+    planned = PlannedContext(context=context, tab_index=0, context_index=0)
+    unit = PlannedExecutionUnit(contexts=[planned], name="strict_unit", index=0)
+
+    generated = unit.get_dynamically_generated_files()
+
+    assert len(generated) == 1
+    assert generated[0].path == "f.txt"
+    assert isinstance(generated[0].content, ContentPath)
+    assert generated[0].content.path == "f.txt"
+
+
+def test_get_dynamically_generated_files_not_dynamic_lax_vs_strict():
+    """Same static ContentPath file: excluded in lax mode, included in strict mode."""
+    static_file = TextData(path="f.txt", content=ContentPath(path="f.txt"))
+
+    # Lax: use_strict_workdir defaults to False
+    lax_testcase = Testcase(
+        input=MainInput(stdin=EmptyChannel.NONE), input_files=[static_file]
+    )
+    lax_context = Context(testcases=[lax_testcase])
+    lax_planned = PlannedContext(context=lax_context, tab_index=0, context_index=0)
+    lax_unit = PlannedExecutionUnit(contexts=[lax_planned], name="lax_unit", index=0)
+
+    assert lax_unit.get_dynamically_generated_files() == []
+
+    # Strict: use_strict_workdir=True
+    strict_testcase = Testcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[static_file],
+        use_strict_workdir=True,
+    )
+    strict_context = Context(testcases=[strict_testcase])
+    strict_planned = PlannedContext(context=strict_context, tab_index=0, context_index=0)
+    strict_unit = PlannedExecutionUnit(
+        contexts=[strict_planned], name="strict_unit", index=0
+    )
+
+    assert len(strict_unit.get_dynamically_generated_files()) == 1
+
+
+def test_has_strict_workdir():
+    """has_strict_workdir() returns True when any context in the unit is strict."""
+    strict_testcase = Testcase(
+        input=MainInput(stdin=EmptyChannel.NONE),
+        input_files=[],
+        use_strict_workdir=True,
+    )
+    lax_testcase = Testcase(input=MainInput(stdin=EmptyChannel.NONE), input_files=[])
+
+    strict_context = Context(testcases=[strict_testcase])
+    lax_context = Context(testcases=[lax_testcase])
+
+    strict_planned = PlannedContext(context=strict_context, tab_index=0, context_index=0)
+    lax_planned = PlannedContext(context=lax_context, tab_index=0, context_index=1)
+
+    mixed_unit = PlannedExecutionUnit(
+        contexts=[lax_planned, strict_planned], name="mixed_unit", index=0
+    )
+    assert mixed_unit.has_strict_workdir() is True
+
+    all_lax_unit = PlannedExecutionUnit(
+        contexts=[lax_planned], name="lax_unit", index=1
+    )
+    assert all_lax_unit.has_strict_workdir() is False


### PR DESCRIPTION
Fixes #622 and the HERE string from #479.
Fixes #575 

- Implement "strict workdir mode" for contexts using `input_files`, in which case only the files explicitly listed will be available in the workdir for the solution.
   - This makes behaviour uniform between referencing existing files vs inline files.
   - If not using `input_files`, nothing changes: the whole workdir is available, as before.
- Tweaked the logic for splitting contexts into execution units
  - More contexts are split into units, taking into account all input files.
  - Previously, e.g. context A with file 1 and context B with file 2 would result in a single unit AB with files 1,2. Now they each get their own unit.
- Support HERE strings (`submission <<< 'stdin'`) for stdin with a single line.


The changes to the strict workdir are technically not backwards compatible, but given that this is a very new feature (and in most cases does what one would expect), I think it is fine to do it.


For reference, contexts are grouped into a single execution unit, unless there is a "conflict". With the updated logic, a conflict occurs in three cases:

- The incoming context's input files differ from the existing ones (meaning context with identical input files are still merged)
- The incoming context has `stdin`
- The current context checks the exit code