### PR TITLE
Fix Python serialization for large ints

### DIFF
--- a/tested/languages/python/templates/values.py
+++ b/tested/languages/python/templates/values.py
@@ -5,7 +5,12 @@ import decimal
 import io
 import json
 import math
+import sys
 import traceback
+
+# If the users make data too large, it should crash on memory issues, or other
+# resource limitations, not a crash in the encoding of values.
+sys.set_int_max_str_digits(0)
 
 
 def encode(value):

--- a/tested/main.py
+++ b/tested/main.py
@@ -3,11 +3,15 @@ Main file, responsible for running TESTed based on the input given by Dodona.
 """
 
 import os
+import sys
 from typing import IO
 
 from tested.configs import DodonaConfig, create_bundle
 from tested.dsl import parse_dsl
 from tested.testsuite import parse_test_suite
+
+# It is better to let it crash using memory or time limits
+sys.set_int_max_str_digits(0)
 
 
 def run(config: DodonaConfig, judge_output: IO):

--- a/tests/exercises/factorial/evaluation/plan.yaml
+++ b/tests/exercises/factorial/evaluation/plan.yaml
@@ -1,0 +1,5 @@
+- tab: "Faculteit"
+  contexts:
+    - testcases:
+        - expression: "faculteit(16)"
+          return: 20922789888000

--- a/tests/exercises/factorial/solution/correct.py
+++ b/tests/exercises/factorial/solution/correct.py
@@ -1,0 +1,5 @@
+def faculteit(n):
+    f = 1
+    for i in range(1, n + 1):
+        f = f * i
+    return f

--- a/tests/exercises/factorial/solution/wrong-large-int.py
+++ b/tests/exercises/factorial/solution/wrong-large-int.py
@@ -1,0 +1,5 @@
+def faculteit(n):
+    f = 1
+    for i in range(1, n):
+        f = (f + i) * f
+    return f

--- a/tests/test_language_quirks.py
+++ b/tests/test_language_quirks.py
@@ -359,3 +359,17 @@ def test_typescript_async(exercise: str, tmp_path: Path, pytestconfig: pytest.Co
     result = execute_config(conf)
     updates = assert_valid_output(result, pytestconfig)
     assert updates.find_status_enum() == ["correct"]
+
+
+def test_python_large_int_wrong_answer(tmp_path: Path, pytestconfig: pytest.Config):
+    conf = configuration(
+        pytestconfig,
+        "factorial",
+        "python",
+        tmp_path,
+        "plan.yaml",
+        "wrong-large-int",
+    )
+    result = execute_config(conf)
+    updates = assert_valid_output(result, pytestconfig)
+    assert updates.find_status_enum() == ["wrong"]


### PR DESCRIPTION
Fixes #629 

Python 3.11 [introduced](https://docs.python.org/3/library/stdtypes.html#integer-string-conversion-length-limitation) a limit on the number of digits for string conversion, as a denial-of-service protection. However, since TESTed runs arbitrary code, those things are limited by time and memory limits. The easiest fix is to just disable the limit.