### PR TITLE
Implement Dodona file linking

### DIFF
--- a/tested/dodona.py
+++ b/tested/dodona.py
@@ -35,11 +35,19 @@ class ExtendedMessage:
 
 
 @define
+class LinkedFile:
+    location: Literal["href", "inline"]
+    # Either a path (type "file") or the content (type "inline")
+    content: str
+
+
+@define
 class Metadata:
-    """Currently only used for the Python tutor"""
+    """Used for the debugger and file linking"""
 
     statements: str | None
     stdin: str | None
+    files: dict[str, LinkedFile] | None
 
 
 Message = ExtendedMessage | str

--- a/tested/judge/core.py
+++ b/tested/judge/core.py
@@ -10,6 +10,7 @@ from tested.dodona import (
     CloseContext,
     CloseJudgement,
     CloseTab,
+    LinkedFile,
     Metadata,
     StartContext,
     StartJudgement,
@@ -367,11 +368,14 @@ def _process_results(
                 # Don't add empty statements
                 meta_statements = None
 
+            meta_files = _get_meta_files(bundle, planned)
+
             collector.add(
                 CloseContext(
                     data=Metadata(
                         statements=meta_statements,
                         stdin=meta_stdin,
+                        files=meta_files,
                     )
                 ),
                 planned.context_index,
@@ -382,3 +386,17 @@ def _process_results(
             return continue_, currently_open_tab
 
     return None, currently_open_tab
+
+
+def _get_meta_files(bundle: Bundle, planned: PlannedContext) -> dict[str, LinkedFile]:
+    meta_files = {}
+    for f in planned.context.get_input_files():
+        display_path = f.get_display_path()
+
+        if display_path is not None:
+            meta_files[f.path] = LinkedFile(location="href", content=display_path)
+        else:
+            contents = f.get_data_as_string(bundle.config.resources)
+            meta_files[f.path] = LinkedFile(location="inline", content=contents)
+
+    return meta_files

--- a/tested/judge/evaluation.py
+++ b/tested/judge/evaluation.py
@@ -384,14 +384,8 @@ def link_files_message(
 ) -> AppendMessage | None:
     link_list = []
     for link_file in link_files:
-        # TODO: handle inline files somehow.
-        link_url = link_file.get_display_path()
-        if link_file.path is not None and link_url is not None:
-            the_url = urllib.parse.quote(link_url)
-            link_list.append(
-                f'<a href="{the_url}" class="file-link" target="_blank">'
-                f'<span class="code">{html.escape(link_file.path)}</span></a>'
-            )
+        if link_file.path is not None:
+            link_list.append(link_file.path)
 
     if len(link_list) == 0:
         return None  # Do not append any message if there are no files.
@@ -400,8 +394,7 @@ def link_files_message(
     file_list_str = get_i18n_string(
         "judge.evaluation.files", count=len(link_list), files=file_list
     )
-    description = f"<div class='contains-file'><p>{file_list_str}</p></div>"
-    message = ExtendedMessage(description=description, format="html")
+    message = ExtendedMessage(description=file_list_str, format="text")
     return AppendMessage(message=message)
 
 

--- a/tested/languages/generation.py
+++ b/tested/languages/generation.py
@@ -2,15 +2,10 @@
 Translates items from the test suite into the actual programming language.
 """
 
-import html
-import json
 import logging
 import re
 import shlex
-import urllib.parse
-from collections.abc import Iterable
 from pathlib import Path
-from re import Match
 from typing import TYPE_CHECKING, TypeAlias
 
 from pygments import highlight
@@ -29,16 +24,8 @@ from tested.languages.preparation import (
     prepare_execution_unit,
     prepare_expression,
 )
-from tested.parsing import get_converter
 from tested.serialisation import Expression, Statement, VariableType
-from tested.testsuite import (
-    ContentPath,
-    Context,
-    LanguageLiterals,
-    MainInput,
-    Testcase,
-    TextData,
-)
+from tested.testsuite import Context, LanguageLiterals, MainInput, Testcase, TextData
 from tested.utils import is_statement_strict
 
 if TYPE_CHECKING:
@@ -75,22 +62,6 @@ def generate_execution_unit(
     :return:
     """
     return bundle.language.generate_execution_unit(prepared_execution)
-
-
-def _handle_link_files(
-    link_files: Iterable[TextData], language: str
-) -> tuple[str, str]:
-    dict_links = dict(
-        (link_file.path, get_converter().unstructure(link_file))
-        for link_file in link_files
-    )
-    files = json.dumps(dict_links)
-    return (
-        f"<div class='contains-file highlight-{language} highlighter-rouge' "
-        f"data-files={repr(files)}><pre style='padding: 2px; margin-bottom: "
-        f"1px; background: none;'><code>",
-        "</code></pre></div>",
-    )
 
 
 def _get_heredoc_token(stdin: str) -> str:
@@ -163,10 +134,6 @@ def get_readable_input(
         if case.line_comment:
             text = f"{text} {bundle.language.comment(case.line_comment)}"
 
-    # If there are no files, return now. This means we don't need to do ugly stuff.
-    if not case.input_files:
-        return ExtendedMessage(description=text, format=format_), set()
-
     # We have potential files.
     # Check if the file names are present in the string.
     # If not, we can also stop before doing ugly things.
@@ -174,50 +141,11 @@ def get_readable_input(
     file_paths = [re.escape(x.path) for x in case.input_files if x.path is not None]
 
     if not file_paths:
-        # No files to match, so bail now.
         return ExtendedMessage(description=text, format=format_), set()
 
-    simple_regex = re.compile("|".join(file_paths))
-
-    if not simple_regex.search(text):
-        # There is no match, so bail now.
-        return ExtendedMessage(description=text, format=format_), set()
-
-    # Now we need to do ugly stuff.
-    # Begin by compiling the HTML that will be displayed.
-    if format_ == "text":
-        generated_html = html.escape(text)
-    elif format_ == "console":
-        generated_html = highlight_code(text)
-    else:
-        generated_html = highlight_code(text, bundle.config.programming_language)
-
-    # Map of file URLs.
-    url_map = {html.escape(x.path): x for x in case.input_files if x.path is not None}
-
-    seen = set()
-    escaped_regex = re.compile("|".join(url_map.keys()))
-
-    # Replaces the match with the corresponding link.
-    def replace_link(match: Match) -> str:
-        filename = match.group()
-        the_file = url_map[filename]
-        the_url = the_file.get_display_path()
-        if the_url is None:
-            # TODO: how to handle inline files?
-            return filename
-
-        quoted_url = urllib.parse.quote(the_url)
-        the_replacement = (
-            f'<a href="{quoted_url}" class="file-link" target="_blank">{filename}</a>'
-        )
-        seen.add(the_file)
-        return the_replacement
-
-    generated_html = escaped_regex.sub(replace_link, generated_html)
-    prefix, suffix = _handle_link_files(seen, format_)
-    generated_html = f"{prefix}{generated_html}{suffix}"
-    return ExtendedMessage(description=generated_html, format="html"), seen
+    path_map = {x.path: x for x in case.input_files if x.path is not None}
+    seen = {path_map[m.group()] for m in re.finditer("|".join(file_paths), text)}
+    return ExtendedMessage(description=text, format=format_), seen
 
 
 def attempt_readable_input(bundle: Bundle, context: Context) -> ExtendedMessage:

--- a/tests/test_file_linking.py
+++ b/tests/test_file_linking.py
@@ -27,10 +27,8 @@ def test_link_files_message_single_file():
 
     assert message
     assert isinstance(message.message, ExtendedMessage)
-    assert message.message.format == "html"
-    assert 'href="media/path/to/data.txt"' in message.message.description
-    assert "data.txt</span></a>" in message.message.description
-    assert "contains-file" in message.message.description
+    assert message.message.format == "text"
+    assert "data.txt" in message.message.description
 
 
 def test_link_files_message_multiple_files():
@@ -43,15 +41,14 @@ def test_link_files_message_multiple_files():
 
     assert message
     assert isinstance(message.message, ExtendedMessage)
-    assert 'href="media/url1"' in message.message.description
-    assert "file1.txt</span></a>" in message.message.description
-    assert 'href="media/url2"' in message.message.description
-    assert "file2.txt</span></a>" in message.message.description
+    assert message.message.format == "text"
+    assert "file1.txt" in message.message.description
+    assert "file2.txt" in message.message.description
     # It should be a comma-separated list
     assert ", " in message.message.description
 
 
-def test_link_files_message_inline_content_ignored():
+def test_link_files_message_includes_inline_files():
     link_files = [
         TextData(path="inline.txt", content="some content"),
         TextData(path="linked.txt", content=ContentPath(path="linked-url")),
@@ -60,9 +57,8 @@ def test_link_files_message_inline_content_ignored():
 
     assert message
     assert isinstance(message.message, ExtendedMessage)
-    assert 'href="media/linked-url"' in message.message.description
-    assert "linked.txt</span></a>" in message.message.description
-    assert "inline.txt" not in message.message.description
+    assert "inline.txt" in message.message.description
+    assert "linked.txt" in message.message.description
 
 
 def test_link_files_message_no_path_ignored():
@@ -95,8 +91,7 @@ def test_readable_input_file_linking(tmp_path: Path, pytestconfig: pytest.Config
     bundle = create_bundle(conf, sys.stdout, suite)
     readable, seen = get_readable_input(bundle, the_input)
 
-    assert 'href="media/path/to/data.txt"' in readable.description
-    assert "data.txt</a>" in readable.description
+    assert "data.txt" in readable.description
     assert the_input.input_files[0] in seen
 
 
@@ -124,8 +119,8 @@ def test_readable_input_multiple_files(tmp_path: Path, pytestconfig: pytest.Conf
     bundle = create_bundle(conf, sys.stdout, suite)
     readable, seen = get_readable_input(bundle, the_input)
 
-    assert 'href="media/url1"' in readable.description
-    assert 'href="media/url2"' in readable.description
+    assert "file1.txt" in readable.description
+    assert "file2.txt" in readable.description
     assert len(seen) == 2
 
 
@@ -151,39 +146,8 @@ def test_readable_input_stdin_file(tmp_path: Path, pytestconfig: pytest.Config):
     bundle = create_bundle(conf, sys.stdout, suite)
     readable, seen = get_readable_input(bundle, the_input)
 
-    # When stdin has a path, the description is "$ submission < input.txt" (or similar)
-    # We want to check if "input.txt" is linked.
-    assert 'href="media/input-url"' in readable.description
-    assert "input.txt</a>" in readable.description
+    assert "input.txt" in readable.description
     assert the_input.input_files[0] in seen
-
-
-def test_readable_input_no_match(tmp_path: Path, pytestconfig: pytest.Config):
-    conf = configuration(
-        pytestconfig,
-        "echo",
-        "python",
-        tmp_path,
-        "plan.yaml",
-        "correct",
-    )
-
-    the_input = Testcase(
-        input=MainInput(
-            arguments=["something-else.txt"],
-        ),
-        input_files=[
-            TextData(path="data.txt", content=ContentPath(path="path/to/data.txt"))
-        ],
-    )
-
-    suite = Suite(tabs=[Tab(contexts=[Context(testcases=[the_input])], name="test")])
-    bundle = create_bundle(conf, sys.stdout, suite)
-    readable, seen = get_readable_input(bundle, the_input)
-
-    # No link should be generated because filenames don't match -> dynamic file.
-    assert "href=" not in readable.description
-    assert len(seen) == 0
 
 
 def test_readable_input_inline_content_no_link(
@@ -209,10 +173,8 @@ def test_readable_input_inline_content_no_link(
     bundle = create_bundle(conf, sys.stdout, suite)
     readable, seen = get_readable_input(bundle, the_input)
 
-    # Inline content should NOT be linked currently
-    assert "href=" not in readable.description
     assert "data.txt" in readable.description
-    assert len(seen) == 0
+    assert len(seen) == 1
 
 
 def test_readable_input_legacy_files(tmp_path: Path, pytestconfig: pytest.Config):
@@ -238,32 +200,25 @@ def test_readable_input_legacy_files(tmp_path: Path, pytestconfig: pytest.Config
     bundle = create_bundle(conf, sys.stdout, suite)
     readable, seen = get_readable_input(bundle, the_input)
 
-    assert 'href="media/legacy-url"' in readable.description
-    assert "legacy.txt</a>" in readable.description
+    assert "legacy.txt" in readable.description
     assert len(seen) == 1
 
 
-def test_link_files_message_url_encoding_spaces():
+def test_link_files_message_emits_raw_filenames():
+    # URL-encoding of the link target now happens on the server. TESTed lists the
+    # filenames verbatim, including spaces and non-ASCII characters.
     link_files = [
-        TextData(path="my file.txt", content=ContentPath(path="path/to/my file.txt"))
-    ]
-    message = link_files_message(link_files)
-    assert message is not None
-    assert isinstance(message.message, ExtendedMessage)
-    assert 'href="media/path/to/my%20file.txt"' in message.message.description
-
-
-def test_link_files_message_url_encoding_unicode():
-    link_files = [
-        TextData(path="résumé.txt", content=ContentPath(path="files/résumé.txt"))
+        TextData(path="my file.txt", content=ContentPath(path="path/to/my file.txt")),
+        TextData(path="résumé.txt", content=ContentPath(path="files/résumé.txt")),
     ]
     message = link_files_message(link_files)
     assert message is not None
     assert isinstance(message.message, ExtendedMessage)
     desc = message.message.description
-    # The href must be percent-encoded, not contain raw non-ASCII chars.
-    assert 'href="media/files/r%C3%A9sum%C3%A9.txt"' in desc
-    assert 'href="files/résumé.txt"' not in desc
+    assert "my file.txt" in desc
+    assert "résumé.txt" in desc
+    assert "href=" not in desc
+    assert "%" not in desc
 
 
 def test_get_display_path_with_override():
@@ -315,8 +270,7 @@ def test_readable_input_with_display_override(
     bundle = create_bundle(conf, sys.stdout, suite)
     readable, seen = get_readable_input(bundle, the_input)
 
-    assert 'href="media/getallen1.txt"' in readable.description
-    assert "getallen1.txt</a>" in readable.description
+    assert "getallen1.txt" in readable.description
     assert the_input.input_files[0] in seen
 
 


### PR DESCRIPTION
Just add the files in the existing `data` field. This allows us to get rid of all HTML generation in TESTed. Implementation might change depending on Dodona PR.

Dodona PR: https://github.com/dodona-edu/dodona/pull/8189
Fixes #603