### PR TITLE
Add matplotlib to dodona-tested dockerfile

### DIFF
--- a/.devcontainer/dodona-tested.dockerfile
+++ b/.devcontainer/dodona-tested.dockerfile
@@ -108,9 +108,10 @@ RUN <<EOF
 
     # Exercise dependencies
     pip install --no-cache-dir --upgrade \
-      numpy==2.3.5 \
-      pandas==3.0.1 \
-      openpyxl==3.1.5
+      numpy==2.4.6 \
+      pandas==3.0.3 \
+      openpyxl==3.1.5 \
+      matplotlib==3.10.9
 
     # Clean up caches
     apt-get clean


### PR DESCRIPTION
## Summary

- Add `matplotlib==3.10.9` to `.devcontainer/dodona-tested.dockerfile`.
- Bump `numpy 2.3.5 → 2.4.6` and `pandas 3.0.1 → 3.0.3` while we're touching the same block.

## Motivation

We already support `matplotlib` in the Pyodide-backed sandbox in Papyros, so students can write and run matplotlib code in the editor — but the `dodona-tested` judge image doesn't have matplotlib installed, so submitting that same code against an exercise fails on import. This PR closes the gap.

Companion python-image PR: dodona-edu/docker-images#404 (covers `dodona-python.dockerfile`, which lives in that repo and is not autogenerated).

## Image size impact

Built locally (arm64) against `master` and against this branch (downstream `dodona-tested` image):

| Image | Before | After | Δ |
|---|---|---|---|
| `dodona-tested` | 5.97 GB | 6.24 GB | +0.27 GB (+4.5%) |

## Test plan

- [ ] After merge, the `push_docker_image.yml` workflow opens a sync PR in dodona-edu/docker-images.
- [ ] On the synced image: `docker run --rm dodona-tested python -c "import matplotlib; print(matplotlib.__version__)"` prints `3.10.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)