### PR TITLE
Use ENV key=value syntax in dodona-tested.dockerfile

### DIFF
--- a/.devcontainer/dodona-tested.dockerfile
+++ b/.devcontainer/dodona-tested.dockerfile
@@ -10,15 +10,15 @@ FROM python:3.12.4-slim-bullseye
 # Set up the environment
 
 # Kotlin
-ENV SDKMAN_DIR /usr/local/sdkman
-ENV PATH $SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
-ENV PATH $SDKMAN_DIR/candidates/java/current/bin:$PATH
+ENV SDKMAN_DIR=/usr/local/sdkman
+ENV PATH=$SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
+ENV PATH=$SDKMAN_DIR/candidates/java/current/bin:$PATH
 # Haskell
-ENV HASKELL_DIR /usr/local/ghcupdir
-ENV PATH $HASKELL_DIR/ghc/bin:$PATH
-ENV PATH $HASKELL_DIR/cabal:$PATH
+ENV HASKELL_DIR=/usr/local/ghcupdir
+ENV PATH=$HASKELL_DIR/ghc/bin:$PATH
+ENV PATH=$HASKELL_DIR/cabal:$PATH
 # Node
-ENV NODE_PATH /usr/lib/node_modules
+ENV NODE_PATH=/usr/lib/node_modules
 
 # Install dependencies
 # hadolint ignore=DL3013,DL3016


### PR DESCRIPTION
## Summary

- Replace the 7 legacy space-separated `ENV key value` declarations in `.devcontainer/dodona-tested.dockerfile` with the `ENV key=value` form.

## Motivation

The downstream build of `dodona-tested` in `dodona-edu/docker-images` emits seven `LegacyKeyValueFormat` BuildKit warnings (originally surfaced on dodona-edu/docker-images#404):

```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)
... (lines 14, 15, 17, 18, 19, 21)
```

See: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

Fixing the source here is the right place — the `push_docker_image` workflow regenerates `docker-images/dodona-tested.dockerfile` from this file on every merge to master, so a fix in the downstream repo would otherwise be overwritten.

This supersedes dodona-edu/docker-images#405, which will be closed once this lands.

## Test plan

- [ ] CI passes.
- [ ] After merge, the auto-generated PR in `dodona-edu/docker-images` includes the `ENV key=value` form.
- [ ] The next `tested` Publish job in `docker-images` builds without `LegacyKeyValueFormat` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)