### PR TITLE
Shrink dodona-tested image (cache/doc/profiling cleanup)

### DIFF
--- a/.devcontainer/dodona-tested.dockerfile
+++ b/.devcontainer/dodona-tested.dockerfile
@@ -26,6 +26,16 @@ RUN <<EOF
     # Update apt-get
     apt-get update
 
+    # Drop docs/man/locale from all apt-installed packages (keep copyright for licensing)
+    cat > /etc/dpkg/dpkg.cfg.d/01_nodoc <<'CFG'
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+CFG
+
     # Install general dependencies
     apt-get install -y --no-install-recommends \
         procps \
@@ -88,6 +98,12 @@ RUN <<EOF
     cabal update
     cabal v1-install --global aeson
 
+    # GHC: drop profiling libs/interfaces, haddock/HTML docs, and debug symbols (unused at runtime)
+    find "$HASKELL_DIR/ghc" -type f \( -name '*_p.a' -o -name '*.p_o' -o -name '*.p_hi' \) -delete
+    rm -rf "$HASKELL_DIR/ghc/share/doc" "$HASKELL_DIR/ghc"/lib/*/doc
+    find "$HASKELL_DIR/ghc" -type f -name '*.so*' -exec strip --strip-unneeded {} + 2>/dev/null || true
+    find "$HASKELL_DIR/ghc/bin" -type f -exec strip --strip-unneeded {} + 2>/dev/null || true
+
     # C# dependencies
     curl https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb --output packages-microsoft-prod.deb
     dpkg -i packages-microsoft-prod.deb
@@ -118,6 +134,14 @@ RUN <<EOF
     rm -rf /root/.cache
     rm -rf /root/.npm
     rm -rf /usr/local/sdkman/tmp
+    # Haskell: downloaded Hackage tarballs and ghcup download cache (aeson lives in GHC's global db)
+    rm -rf /root/.cabal/packages /root/.cabal/logs /root/.ghcup/cache /root/.ghcup/tmp
+    # .NET: NuGet/dotnet download and first-run caches (SDK itself untouched)
+    rm -rf /root/.nuget /root/.dotnet /tmp/NuGet* /tmp/.dotnet "${HOME}/.local/share/NuGet"
+    # sdkman: extracted JDK/Kotlin zips, plus JDK sources and man pages (not needed to compile/run)
+    rm -rf "$SDKMAN_DIR/archives/"* "$SDKMAN_DIR/tmp/"*
+    rm -f  "$SDKMAN_DIR"/candidates/java/*/src.zip
+    rm -rf "$SDKMAN_DIR"/candidates/java/*/man "$SDKMAN_DIR"/candidates/kotlin/*/licenses
 
     # Setup permissions and user
     chmod 711 /mnt


### PR DESCRIPTION
This PR removes:

1. **dpkg doc/man pages**: through a `dpkg.cfg.d/01_nodoc` config added before the first `apt-get install`, so every apt package skips `/usr/share/{doc,man,groff,info,locale}` (copyright files retained for licensing).
2. **GHC slimming**: delete profiling libraries/interfaces (`*_p.a`, `*.p_o`, `*.p_hi`), haddock/HTML docs, and `strip --strip-unneeded` on GHC libs and binaries.
3. **Cache/archive cleanup**: extend the existing cleanup block to remove cabal/ghcup download caches, NuGet/dotnet caches, sdkman archives, the JDK `src.zip` + man pages, and kotlin licenses.

### Result

| | Image size |
|---|---|
| `origin/master` (rebuilt) | 6.08 GB |
| this branch | **4.33 GB** |

≈ **1.75 GB smaller (−29%)** on arm64, measured against `master`.

## How to test

Build and smoke-test each language:

```sh
docker build -f .devcontainer/dodona-tested.dockerfile -t tested .devcontainer
docker run --rm tested bash -c '
  echo "main = putStrLn \"ok\"" > /tmp/H.hs && ghc -o /tmp/h /tmp/H.hs && /tmp/h   # Haskell
  ghc-pkg list aeson                                                                # aeson registered
  echo "public class M{public static void main(String[] a){System.out.println(1);}}" > /tmp/M.java && (cd /tmp && javac M.java && java M)
  echo "fun main(){println(1)}" > /tmp/k.kt && kotlinc /tmp/k.kt -include-runtime -d /tmp/k.jar && java -jar /tmp/k.jar
  dotnet --version                                                                  # C# SDK (amd64)
  python -c "import psutil, numpy, pandas, openpyxl"                                # python deps (amd64 wheel)
  pylint --version && hlint --version && shellcheck --version && cppcheck --version && ktlint --version && eslint --version && tsc --version
'
```