### PR TITLE
Use a GitHub App token to sync the dodona-tested dockerfile

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -37,12 +37,9 @@ jobs:
           FOLDER="docker-images"
           BRANCH_NAME="update-dodona-tested-$PR_NUMBER"
 
-          # Store the app token in a file that can be accessed by the
-          # GitHub CLI.
-          echo "$TOKEN" > token.txt
-
-          # Authorize GitHub CLI for the current repository
-          gh auth login --with-token < token.txt
+          # Authorize GitHub CLI for the current repository, piping the token
+          # straight in so it never touches disk.
+          echo "$TOKEN" | gh auth login --with-token
 
           gh repo clone $REPOSITORY $FOLDER -- --depth=1
           

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Generate a token for dodona-edu/docker-images
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PUSH_TO_DOCKER_IMAGES_APP_ID }}
           private-key: ${{ secrets.PUSH_TO_DOCKER_IMAGES_PRIVATE_KEY }}

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -9,10 +9,11 @@ on:
       - closed
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   pr:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     name: Create pr for docker image
     runs-on: ubuntu-latest
     steps:
@@ -28,14 +29,26 @@ jobs:
           repositories: docker-images
       - name: Send pull-request
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
           REPOSITORY: dodona-edu/docker-images
           TOKEN: ${{ steps.app-token.outputs.token }}
           USER: dodona-server
           EMAIL: dodona@ugent.be
         run: |
           FOLDER="docker-images"
-          BRANCH_NAME="update-dodona-tested-$PR_NUMBER"
+
+          # On a merged PR we key everything off its number; on a manual
+          # (workflow_dispatch) run there is no PR, so fall back to the run id.
+          if [ -n "$PR_NUMBER" ]; then
+            BRANCH_NAME="update-dodona-tested-$PR_NUMBER"
+            PR_TITLE="Update dodona-tested dockerfile to match pr #$PR_NUMBER"
+            PR_BODY="This pr updates the dodona-tested dockerfile to match pr https://github.com/dodona-edu/universal-judge/pull/$PR_NUMBER"
+          else
+            BRANCH_NAME="update-dodona-tested-manual-$RUN_ID"
+            PR_TITLE="Update dodona-tested dockerfile"
+            PR_BODY="This pr updates the dodona-tested dockerfile to match the latest dodona-edu/universal-judge master (triggered manually)."
+          fi
 
           # Authorize GitHub CLI for the current repository, piping the token
           # straight in so it never touches disk.
@@ -75,8 +88,7 @@ jobs:
           
           # Create a pull request in the remote repository
           gh pr create \
-            --body "" \
-            --title "Update dodona-tested dockerfile to match pr #$PR_NUMBER" \
-            --body "This pr updates the dodona-tested dockerfile to match pr https://github.com/dodona-edu/universal-judge/pull/$PR_NUMBER" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
             --head "$BRANCH_NAME" \
             --base "master"

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -18,24 +18,32 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Generate a token for dodona-edu/docker-images
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PUSH_TO_DOCKER_IMAGES_APP_ID }}
+          private-key: ${{ secrets.PUSH_TO_DOCKER_IMAGES_PRIVATE_KEY }}
+          owner: dodona-edu
+          repositories: docker-images
       - name: Send pull-request
         env:
           PR_NUMBER: ${{ github.event.number }}
           REPOSITORY: dodona-edu/docker-images
-          TOKEN: ${{ secrets.PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
           USER: dodona-server
           EMAIL: dodona@ugent.be
         run: |
           FOLDER="docker-images"
           BRANCH_NAME="update-dodona-tested-$PR_NUMBER"
-          
-          # Store the PAT in a file that can be accessed by the
+
+          # Store the app token in a file that can be accessed by the
           # GitHub CLI.
           echo "$TOKEN" > token.txt
-          
+
           # Authorize GitHub CLI for the current repository
           gh auth login --with-token < token.txt
-          
+
           gh repo clone $REPOSITORY $FOLDER -- --depth=1
           
           cd $FOLDER


### PR DESCRIPTION
Two changes to the `push_docker_image` workflow:

1. **GitHub App token instead of a PAT.** Switches from the `PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN` PAT to a short-lived GitHub App installation token, generated with `actions/create-github-app-token@v3`. 

2. **Manual trigger.** Adds a `workflow_dispatch` trigger so the dockerfile can be re-synced on demand

## Testing
Can't be tested here