### PR TITLE
Report error line numbers relative to the original submission

### DIFF
--- a/tested/languages/c/config.py
+++ b/tested/languages/c/config.py
@@ -114,9 +114,14 @@ class C(Language):
             with_args = re.compile(r"(int|void)(\s+)main(\s*)\((\s*)int")
             replacement = r"int\2solution_main\3(\4int"
             contents = re.sub(with_args, replacement, contents, count=1)
+        assert self.config
         with open(solution, "w") as file:
             header = "#pragma once\n\n"
             file.write(header + contents)
+        # The header prepends `header` lines in front of the student's code, so
+        # error line numbers are shifted down by that many lines. Correct it the
+        # same way JavaScript/TypeScript do (see their `modify_solution`).
+        self.config.dodona.source_offset -= header.count("\n")
 
     def linter(self, remaining: float) -> tuple[list[Message], list[AnnotateCode]]:
         # Import locally to prevent errors.

--- a/tested/languages/cpp/config.py
+++ b/tested/languages/cpp/config.py
@@ -131,9 +131,14 @@ class CPP(Language):
             with_args = re.compile(r"(int|void)(\s+)main(\s*)\((\s*)int")
             replacement = r"int\2solution_main\3(\4int"
             contents = re.sub(with_args, replacement, contents, count=1)
+        assert self.config
         with open(solution, "w") as file:
             header = "#pragma once\n\n"
             file.write(header + contents)
+        # The header prepends `header` lines in front of the student's code, so
+        # error line numbers are shifted down by that many lines. Correct it the
+        # same way JavaScript/TypeScript do (see their `modify_solution`).
+        self.config.dodona.source_offset -= header.count("\n")
 
     def linter(self, remaining: float) -> tuple[list[Message], list[AnnotateCode]]:
         # Import locally to prevent errors.

--- a/tested/languages/csharp/config.py
+++ b/tested/languages/csharp/config.py
@@ -140,6 +140,7 @@ class CSharp(Language):
             return Status.COMPILATION_ERROR
 
     def modify_solution(self, solution: Path):
+        assert self.config
         with open(solution, "r") as file:
             contents = file.read()
 
@@ -169,18 +170,29 @@ class {class_name}
         with open(solution, "w") as file:
             file.write(result)
 
+        # The wrapper prepends 12 lines in front of the student's code, so every
+        # line number reported by the compiler or runtime is shifted down by 12.
+        # Correct it the same way JavaScript/TypeScript do (see their
+        # `modify_solution`).
+        self.config.dodona.source_offset -= 12
+
     def cleanup_stacktrace(self, stacktrace: str) -> str:
         assert self.config
         execution = conventionalize_namespace(self, EXECUTION_PREFIX)
         execution_submission_location_regex = (
             rf"{self.config.dodona.workdir}/common/{execution}[0-9]+.cs"
         )
-        submission_location = (
-            self.config.dodona.workdir / "common" / submission_file(self)
-        )
-        submission_location_regex = rf"{submission_location.resolve()}:line ([0-9]+)"
-        compilation_location_regex = rf"{submission_location.resolve()}\((\d+),(\d+)\)"
-        compilation_suffix = f" [{self.config.dodona.workdir}/common/dotnet.csproj]"
+        # A runtime error references the submission in `common/`, but a compile
+        # error surfaces from the per-unit compilation fallback, where the
+        # submission lives in an `ExecutionN/` directory. Match either so the path
+        # is replaced with `<code>` (and the line offset applied downstream) in
+        # both cases.
+        workdir = re.escape(str(self.config.dodona.workdir.resolve()))
+        subdir = rf"(?:common|{execution}[_0-9]+)"
+        sub = re.escape(submission_file(self))
+        submission_location_regex = rf"{workdir}/{subdir}/{sub}:line ([0-9]+)"
+        compilation_location_regex = rf"{workdir}/{subdir}/{sub}\((\d+),(\d+)\)"
+        compilation_suffix_regex = rf" \[{workdir}/{subdir}/dotnet\.csproj\]"
 
         resulting_lines = ""
         for line in stacktrace.splitlines(keepends=True):
@@ -195,7 +207,7 @@ class {class_name}
 
             line = re.sub(submission_location_regex, r"<code>:\1", line)
             line = re.sub(compilation_location_regex, r"<code>:\1:\2", line)
-            line = line.replace(compilation_suffix, "")
+            line = re.sub(compilation_suffix_regex, "", line)
             resulting_lines += line
 
         return resulting_lines
@@ -203,16 +215,25 @@ class {class_name}
     def compiler_output(
         self, stdout: str, stderr: str
     ) -> tuple[list[Message], list[AnnotateCode], str, str]:
+        assert self.config
         submission = submission_name(self)
         message_regex = (
-            rf"{submission}\((\d+),(\d+)\): (error|warning) ([A-Z0-9]+): (.*) \["
+            rf"{submission}\.cs\((\d+),(\d+)\): (error|warning) ([A-Z0-9]+): (.*) \["
         )
         messages = re.findall(message_regex, stdout)
         annotations = []
         for message in messages:
+            # The compiler reports the line number in the wrapped file; shift it
+            # back to the original submission (the offset is negative).
+            row = int(message[0]) + self.config.dodona.source_offset
+            # Diagnostics on the generated wrapper (the usings/class/Main we
+            # prepend) land on rows <= 0; they are not the student's code, so
+            # skip them rather than annotate a non-existent line.
+            if row < 1:
+                continue
             annotations.append(
                 AnnotateCode(
-                    row=int(message[0]),
+                    row=row,
                     text=message[4],
                     externalUrl="https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/",
                     column=int(message[1]),

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -467,3 +467,173 @@ def test_code_is_linked():
     )
     actual = _convert_stacktrace_to_html(stacktrace).description
     assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #596: error line numbers must point at the original
+# submission, not at the template the judge wraps it in. The wrapping
+# languages (C#, C, C++) decrement `source_offset` in `modify_solution`; the
+# offset is applied downstream by `_replace_code_line_number` (the same
+# mechanism JavaScript/TypeScript already use).
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_modify_solution_wraps_and_offsets(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "csharp")
+    solution = tmp_path / "Submission.cs"
+    solution.write_text("Console.WriteLine(foo);\n")  # top-level statements
+    language_config.modify_solution(solution)
+    wrapped = solution.read_text()
+    assert "class Submission" in wrapped
+    assert "static void Main" in wrapped
+    # 12 wrapper lines are prepended, so the compiler/runtime report line numbers
+    # 12 too high; the offset corrects for that.
+    assert language_config.config.dodona.source_offset == -12
+    # The student's first line is now physical line 13 of the wrapped file.
+    assert wrapped.splitlines()[12].strip() == "Console.WriteLine(foo);"
+
+
+def test_csharp_modify_solution_explicit_class_keeps_offset(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "csharp")
+    original = "class Submission { static void Main() { } }\n"
+    solution = tmp_path / "Submission.cs"
+    solution.write_text(original)
+    language_config.modify_solution(solution)
+    # An explicit class is not wrapped, so nothing shifts.
+    assert solution.read_text() == original
+    assert language_config.config.dodona.source_offset == 0
+
+
+def test_c_modify_solution_offsets(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "c")
+    solution = tmp_path / "submission.c"
+    solution.write_text("int main() {\n    return 0;\n}\n")
+    language_config.modify_solution(solution)
+    assert language_config.config.dodona.source_offset == -2
+    assert solution.read_text().startswith("#pragma once\n\n")
+
+
+def test_cpp_modify_solution_offsets(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "cpp")
+    solution = tmp_path / "submission.cpp"
+    solution.write_text("int main() {\n    return 0;\n}\n")
+    language_config.modify_solution(solution)
+    assert language_config.config.dodona.source_offset == -2
+    assert solution.read_text().startswith("#pragma once\n\n")
+
+
+def test_csharp_compiler_output_offsets_annotation_row():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    language_config.config.dodona.source_offset = -12  # as set by modify_solution
+    stdout = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"The name 'foo' does not exist in the current context "
+        f"[{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    _, annotations, _, _ = language_config.compiler_output(stdout, "")
+    assert len(annotations) == 1
+    annotation = annotations[0]
+    assert annotation.row == 2  # 14 reported - 12 wrapper lines
+    assert annotation.column == 19
+    assert annotation.type == "error"
+    assert annotation.text == "The name 'foo' does not exist in the current context"
+
+
+def test_csharp_compiler_output_offsets_multiple_annotations():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    language_config.config.dodona.source_offset = -12
+    stdout = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"undefined [{workdir}/Execution0/dotnet.csproj]\n"
+        f"{workdir}/Execution0/Submission.cs(16,9): warning CS0219: "
+        f"unused [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    _, annotations, _, _ = language_config.compiler_output(stdout, "")
+    assert [(a.row, a.type) for a in annotations] == [(2, "error"), (4, "warning")]
+
+
+def test_csharp_compiler_output_skips_wrapper_diagnostics():
+    # A diagnostic on the generated wrapper (e.g. an unused `using` on line 1)
+    # maps to a non-positive row after the offset and must not be annotated.
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    language_config.config.dodona.source_offset = -12
+    stdout = (
+        f"{workdir}/Execution0/Submission.cs(1,1): warning CS8019: "
+        f"Unnecessary using directive. [{workdir}/Execution0/dotnet.csproj]\n"
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"undefined [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    _, annotations, _, _ = language_config.compiler_output(stdout, "")
+    # The wrapper warning (row 1 -> -11) is skipped; only the student error stays.
+    assert [(a.row, a.type) for a in annotations] == [(2, "error")]
+
+
+def test_csharp_cleanup_stacktrace_execution_dir_compile():
+    # A real compile error surfaces from the per-unit fallback (ExecutionN/),
+    # not common/. It must still be cleaned to <code> with its csproj suffix
+    # stripped (the existing test only covers common/).
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    original = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"The name 'foo' does not exist [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    expected = "<code>:14:19: error CS0103: The name 'foo' does not exist\n"
+    assert language_config.cleanup_stacktrace(original) == expected
+
+
+def test_csharp_runtime_line_offset_end_to_end():
+    # The full path a runtime exception takes: cleanup_stacktrace -> <code>:N,
+    # then _replace_code_line_number applies the offset.
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    language_config.config.dodona.source_offset = -12
+    original = (
+        f"at Submission.Main(String[] args) in "
+        f"{workdir}/common/Submission.cs:line 15\n"
+    )
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "at Submission.Main(String[] args) in <code>:3\n"
+
+
+def test_csharp_compile_line_offset_end_to_end():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    language_config.config.dodona.source_offset = -12
+    original = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"undefined [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "<code>:2:19: error CS0103: undefined\n"
+
+
+def test_c_compile_line_offset_end_to_end():
+    language_config = get_language("test", "c")
+    language_config.config.dodona.source_offset = -2
+    original = "submission.c:3:1: fout: unknown type name 'mfzej'\n"
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "<code>:1:1: fout: unknown type name 'mfzej'\n"
+
+
+def test_cpp_compile_line_offset_end_to_end():
+    language_config = get_language("test", "cpp")
+    language_config.config.dodona.source_offset = -2
+    original = "submission.cpp:3:1: error: 'mfzej' does not name a type\n"
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "<code>:1:1: error: 'mfzej' does not name a type\n"


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

Closes #596 (error line numbers pointing at the templated code instead of the original submission; #435 was the same class of bug in another language).

### What

The C#, C and C++ judges wrap the student's submission before compiling: C# wraps top-level statements in `class Submission { Main { ... } }` (12 prepended lines), and C/C++ prepend a `#pragma once` header (2 lines). Error line numbers were reported relative to that wrapped file, so the clickable stack-trace links and code annotations pointed 12 (or 2) lines too low, often past the end of a short submission.

This corrects it the way JavaScript and TypeScript already do: `modify_solution` decrements `config.dodona.source_offset` by the number of prepended lines, and the existing `_replace_code_line_number` then maps every `<code>:N` reference back to the original line. C, C++ and C# all wrap but skipped this step.

On the C# compile path I also fixed two adjacent things:

- `cleanup_stacktrace` only matched the submission in `common/`, but a compile error actually surfaces from the per-unit compilation fallback in an `ExecutionN/` directory. It now matches either (and strips the matching `dotnet.csproj` suffix), so the internal `…/ExecutionN/…` path stops leaking and the offset is applied to compile errors too.
- the `compiler_output` annotation regex was `Submission(...)` but the compiler emits `Submission.cs(...)`, so it never matched and C# compile annotations were silently dead. Fixed the regex, applied the offset to the annotation row, and skip diagnostics that land on the generated wrapper (which map to a non-positive row).

### Tests

Adds coverage for every branch that previously had none: `modify_solution` (the offset, plus the wrap and explicit-`class` branches), `compiler_output` (annotation extraction, multiple diagnostics, wrapper-line skipping), `cleanup_stacktrace` for the new `ExecutionN/` compile path, and end-to-end offset application, across C#, C and C++.

### Verification

- `pytest tests/test_stacktrace_cleaners.py` passes (45 tests); `black` and `isort` are clean.
- Ran the actual judge (`dodona-tested`, .NET 8) on a class-less C# submission that throws at runtime on its 3rd line: the stack-trace link now points at `data-line="3"` instead of `15`.

### One thing I noticed, separate from this PR

On current `master`, when precompilation fails and falls back to per-unit compilation, the compile-error detail (message + annotations) seems to be discarded, so only the `compilation error` status is shown with no line at all. An older revision did show the detail, so this looks like a pre-existing regression unrelated to line numbers. The C# compile-path corrections above are still correct, but they are not visible end-to-end until that is sorted. I can look into it separately if it is worth a ticket.
