### PR TITLE
Report C#, C and C++ error line numbers relative to the original submission

### DIFF
--- a/tested/languages/c/config.py
+++ b/tested/languages/c/config.py
@@ -114,9 +114,11 @@ class C(Language):
             with_args = re.compile(r"(int|void)(\s+)main(\s*)\((\s*)int")
             replacement = r"int\2solution_main\3(\4int"
             contents = re.sub(with_args, replacement, contents, count=1)
+        assert self.config
         with open(solution, "w") as file:
             header = "#pragma once\n\n"
             file.write(header + contents)
+        self.config.dodona.source_offset -= header.count("\n")
 
     def linter(self, remaining: float) -> tuple[list[Message], list[AnnotateCode]]:
         # Import locally to prevent errors.

--- a/tested/languages/cpp/config.py
+++ b/tested/languages/cpp/config.py
@@ -131,9 +131,11 @@ class CPP(Language):
             with_args = re.compile(r"(int|void)(\s+)main(\s*)\((\s*)int")
             replacement = r"int\2solution_main\3(\4int"
             contents = re.sub(with_args, replacement, contents, count=1)
+        assert self.config
         with open(solution, "w") as file:
             header = "#pragma once\n\n"
             file.write(header + contents)
+        self.config.dodona.source_offset -= header.count("\n")
 
     def linter(self, remaining: float) -> tuple[list[Message], list[AnnotateCode]]:
         # Import locally to prevent errors.

--- a/tested/languages/csharp/config.py
+++ b/tested/languages/csharp/config.py
@@ -140,6 +140,7 @@ class CSharp(Language):
             return Status.COMPILATION_ERROR
 
     def modify_solution(self, solution: Path):
+        assert self.config
         with open(solution, "r") as file:
             contents = file.read()
 
@@ -147,7 +148,7 @@ class CSharp(Language):
             return  # No top-level statements; we are happy...
 
         class_name = submission_name(self)
-        result = f"""\
+        header = f"""\
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -160,14 +161,17 @@ class {class_name}
 {{
     public static void Main(string[] args)
     {{
-        {contents}
-    }}
-}}
-        """
+"""
+        footer = """
+    }
+}
+"""
 
         # noinspection PyTypeChecker
         with open(solution, "w") as file:
-            file.write(result)
+            file.write(header + contents + footer)
+
+        self.config.dodona.source_offset -= header.count("\n")
 
     def cleanup_stacktrace(self, stacktrace: str) -> str:
         assert self.config

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -467,3 +467,87 @@ def test_code_is_linked():
     )
     actual = _convert_stacktrace_to_html(stacktrace).description
     assert actual == expected
+
+
+def test_csharp_modify_solution_wraps_and_offsets(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "csharp")
+    assert language_config.config
+    solution = tmp_path / "Submission.cs"
+    solution.write_text("Console.WriteLine(foo);\n")
+    language_config.modify_solution(solution)
+    wrapped = solution.read_text()
+    assert "class Submission" in wrapped
+    assert "static void Main" in wrapped
+    assert language_config.config.dodona.source_offset == -12
+    assert wrapped.splitlines()[12] == "Console.WriteLine(foo);"
+
+
+def test_csharp_modify_solution_explicit_class_keeps_offset(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "csharp")
+    assert language_config.config
+    original = "class Submission { static void Main() { } }\n"
+    solution = tmp_path / "Submission.cs"
+    solution.write_text(original)
+    language_config.modify_solution(solution)
+    assert solution.read_text() == original
+    assert language_config.config.dodona.source_offset == 0
+
+
+def test_c_modify_solution_offsets(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "c")
+    assert language_config.config
+    solution = tmp_path / "submission.c"
+    solution.write_text("int main() {\n    return 0;\n}\n")
+    language_config.modify_solution(solution)
+    assert language_config.config.dodona.source_offset == -2
+    assert solution.read_text().startswith("#pragma once\n\n")
+
+
+def test_cpp_modify_solution_offsets(tmp_path: Path):
+    language_config = get_language(str(tmp_path), "cpp")
+    assert language_config.config
+    solution = tmp_path / "submission.cpp"
+    solution.write_text("int main() {\n    return 0;\n}\n")
+    language_config.modify_solution(solution)
+    assert language_config.config.dodona.source_offset == -2
+    assert solution.read_text().startswith("#pragma once\n\n")
+
+
+def test_csharp_runtime_line_offset_end_to_end():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -12
+    original = (
+        f"at Submission.Main(String[] args) in "
+        f"{workdir}/common/Submission.cs:line 15\n"
+    )
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "at Submission.Main(String[] args) in <code>:3\n"
+
+
+def test_c_compile_line_offset_end_to_end():
+    language_config = get_language("test", "c")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -2
+    original = "submission.c:3:1: fout: unknown type name 'mfzej'\n"
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "<code>:1:1: fout: unknown type name 'mfzej'\n"
+
+
+def test_cpp_compile_line_offset_end_to_end():
+    language_config = get_language("test", "cpp")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -2
+    original = "submission.cpp:3:1: error: 'mfzej' does not name a type\n"
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "<code>:1:1: error: 'mfzej' does not name a type\n"


### PR DESCRIPTION
When we "script" in C# without adding a class & main method, TESTed wraps our code in a class & main method, and also adds some imports. We don't account for that yet when cleaning up the stacktrace, causing us to report wrong line numbers.

During the discovery, we apparently have the same issue for C and C++ where we add a pragma + a newline.

This PR strips those headers that we add so the line number reporting is correct.

But there's more: for C#, there's another bug that's causing compile errors not to pass through the cleanup path. So here, we only address C# runtime errors, and all C and C++ errors.

The reason for that is that runtime errors pass end up in the `/common/` path, which we clean, but compile errors surface in a different path that doesn't match the regex we have at https://github.com/dodona-edu/universal-judge/blob/785e6433883abfcf9b89a9c8bd415613c4e306da/tested/languages/csharp/config.py#L179-L181

We'll fix that in a followup PR to focus on line numbers caused by headers here.

And there's even more:

Even if we fix the headers that C and C++ add, there's other line numbers that get offset too, for example:

```
[<code>:6](http://dodona.localhost:3000/en/activities/1437968791/#):5: error: ‘undeclared_var’ was not declared in this scope
    8 |     undeclared_var = 5;   // line 6
      |     ^~~~~~~~~~~~~~
```

`<code>:6` is fine here, but `8 |` isn't, should be `6 |`. Out of scope for this PR.

## Manual testing

For each language: submit the snippet on `master` and note the line number in the
stack-trace link, then point your TESTed at this branch and resubmit. The link should move from the wrapped line to the student's original line.

### C# (runtime error)

```csharp
Console.WriteLine("start");
int[] getallen = new int[2];
Console.WriteLine(getallen[10]);   // line 3
```

- **master:** `IndexOutOfRangeException: Index was outside the bounds of the array. at Submission.Main(String[] args) in <code>:15`
- **this branch:** `... in <code>:3`

### C (compile error)

```c
#include <stdio.h>
int main() {
    int a = 1;
    int b = 2;
    int c = 3;
    undeclared_var = 5;   // line 6
    return 0;
}
```

- **master:** `<code>:8: error: 'undeclared_var' undeclared (first use in this function)`
- **this branch:** `<code>:6`

### C++ (compile error)

```cpp
#include <iostream>
int main() {
    int a = 1;
    int b = 2;
    int c = 3;
    undeclared_var = 5;   // line 6
    return 0;
}
```

- **master:** `<code>:8: error: 'undeclared_var' was not declared in this scope`
- **this branch:** `<code>:6`

<details>

First of a **3-PR stack** that splits the original #652 into reviewable pieces:
1. **this PR** the line-number offset itself (C#, C, C++);
9. #654 C# `cleanup_stacktrace`: also clean the compile-error path from the per-unit fallback;
10. #655 C# `compiler_output`: resurrect the currently-dead compile annotations.

### What

The C#, C and C++ judges wrap the student's submission before compiling: C# wraps top-level statements in `class Submission { Main { ... } }` (12 prepended lines), and C/C++ prepend a `#pragma once` header (2 lines). Error line numbers were reported relative to that wrapped file, so the clickable stack-trace links and code annotations pointed 12 (or 2) lines too low, often past the end of a short submission.

This corrects it the way JavaScript and TypeScript already do: `modify_solution` decrements `config.dodona.source_offset` by the number of prepended lines, and the existing `_replace_code_line_number` then maps every `<code>:N` back to the original line. C, C++ and C# all wrap but skipped this step.

### Tests

`modify_solution` had no tests. Adds them for the offset and the wrap / explicit-`class` branches, plus end-to-end offset application (runtime for C#, compile for C and C++).

### Verification

- `pytest tests/test_stacktrace_cleaners.py` passes; `black` and `isort` are clean.
- Ran the judge (`dodona-tested`, .NET 8) on a class-less C# submission that throws on its 3rd line: the stack-trace link now points at `data-line="3"` instead of `15`.
</details>

Updates #596