### PR TITLE
Clean the C# compile-error path from the per-unit fallback

### DIFF
--- a/tested/languages/csharp/config.py
+++ b/tested/languages/csharp/config.py
@@ -179,12 +179,12 @@ class {class_name}
         execution_submission_location_regex = (
             rf"{self.config.dodona.workdir}/common/{execution}[0-9]+.cs"
         )
-        submission_location = (
-            self.config.dodona.workdir / "common" / submission_file(self)
-        )
-        submission_location_regex = rf"{submission_location.resolve()}:line ([0-9]+)"
-        compilation_location_regex = rf"{submission_location.resolve()}\((\d+),(\d+)\)"
-        compilation_suffix = f" [{self.config.dodona.workdir}/common/dotnet.csproj]"
+        workdir = re.escape(str(self.config.dodona.workdir.resolve()))
+        subdir = rf"(?:common|{execution}[_0-9]+)"
+        sub = re.escape(submission_file(self))
+        submission_location_regex = rf"{workdir}/{subdir}/{sub}:line ([0-9]+)"
+        compilation_location_regex = rf"{workdir}/{subdir}/{sub}\((\d+),(\d+)\)"
+        compilation_suffix_regex = rf" \[{workdir}/{subdir}/dotnet\.csproj\]"
 
         resulting_lines = ""
         for line in stacktrace.splitlines(keepends=True):
@@ -199,7 +199,7 @@ class {class_name}
 
             line = re.sub(submission_location_regex, r"<code>:\1", line)
             line = re.sub(compilation_location_regex, r"<code>:\1:\2", line)
-            line = line.replace(compilation_suffix, "")
+            line = re.sub(compilation_suffix_regex, "", line)
             resulting_lines += line
 
         return resulting_lines

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -551,3 +551,30 @@ def test_cpp_compile_line_offset_end_to_end():
         language_config.config.dodona.source_offset, cleaned
     )
     assert final == "<code>:1:1: error: 'mfzej' does not name a type\n"
+
+
+def test_csharp_cleanup_stacktrace_execution_dir_compile():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    original = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"The name 'foo' does not exist [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    expected = "<code>:14:19: error CS0103: The name 'foo' does not exist\n"
+    assert language_config.cleanup_stacktrace(original) == expected
+
+
+def test_csharp_compile_line_offset_end_to_end():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -12
+    original = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"undefined [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    cleaned = language_config.cleanup_stacktrace(original)
+    final = _replace_code_line_number(
+        language_config.config.dodona.source_offset, cleaned
+    )
+    assert final == "<code>:2:19: error CS0103: undefined\n"


### PR DESCRIPTION
Part of #596. Follows up #653 where we fixed the line number offset in runtime errors on C# exercises. During that fix, we noticed that this didn't work for compilation errors yet. The issue was that we only cleaned the stacktrace on the `/common/` path, but since compilation errors happen on the `/ExecutionN/` path, they weren't considered to clean this up.

### Manual tests
1. On main, submit a C# exercise that results into a compilation error (e.g. just a simple `foo` will do)
2. Assert the compilation error message isn't cleaned: `/home/runner/workdir/Execution0/Submission.cs(13,12): error CS1002: ; expected [/home/runner/workdir/Execution0/dotnet.csproj]`
3. Resubmit on this branch, assert the message is now cleaned to `<code>`:1:4: (a) the path …/Execution0/Submission.cs(…) is replaced with `<code>`, and (b) the line is corrected 13 → 1.
4. Resubmit on this branch with a "full C# program (with `class Submission`) and assert that the line number and column number still point to the correct place 

<details>

### What

When precompilation fails, the C# judge falls back to compiling each unit on its own, and a compile error then references the submission in an `ExecutionN/` directory instead of `common/`. `cleanup_stacktrace` only matched `common/`, so on that path the internal `.../ExecutionN/...` path leaked into the feedback and the line offset from #653 was never applied.

This matches either `common/` or `ExecutionN/` for the submission location and strips the matching `dotnet.csproj` suffix, so compile errors are cleaned to `<code>:N` (and offset-corrected) just like runtime errors already are. The existing `common/` test still passes.

### Tests

Adds an `ExecutionN/` compile-path cleanup test (the existing one only covered `common/`) and an end-to-end compile-line offset test.

</details>
