### PR TITLE
Resurrect the dead C# compile-error annotations

### DIFF
--- a/tested/languages/csharp/config.py
+++ b/tested/languages/csharp/config.py
@@ -207,16 +207,20 @@ class {class_name}
     def compiler_output(
         self, stdout: str, stderr: str
     ) -> tuple[list[Message], list[AnnotateCode], str, str]:
+        assert self.config
         submission = submission_name(self)
         message_regex = (
-            rf"{submission}\((\d+),(\d+)\): (error|warning) ([A-Z0-9]+): (.*) \["
+            rf"{submission}\.cs\((\d+),(\d+)\): (error|warning) ([A-Z0-9]+): (.*) \["
         )
         messages = re.findall(message_regex, stdout)
         annotations = []
         for message in messages:
+            row = int(message[0]) + self.config.dodona.source_offset
+            if row < 1:
+                continue
             annotations.append(
                 AnnotateCode(
-                    row=int(message[0]),
+                    row=row,
                     text=message[4],
                     externalUrl="https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/",
                     column=int(message[1]),

--- a/tests/test_stacktrace_cleaners.py
+++ b/tests/test_stacktrace_cleaners.py
@@ -578,3 +578,52 @@ def test_csharp_compile_line_offset_end_to_end():
         language_config.config.dodona.source_offset, cleaned
     )
     assert final == "<code>:2:19: error CS0103: undefined\n"
+
+
+def test_csharp_compiler_output_offsets_annotation_row():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -12
+    stdout = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"The name 'foo' does not exist in the current context "
+        f"[{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    _, annotations, _, _ = language_config.compiler_output(stdout, "")
+    assert len(annotations) == 1
+    annotation = annotations[0]
+    assert annotation.row == 2
+    assert annotation.column == 19
+    assert annotation.type == "error"
+    assert annotation.text == "The name 'foo' does not exist in the current context"
+
+
+def test_csharp_compiler_output_offsets_multiple_annotations():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -12
+    stdout = (
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"undefined [{workdir}/Execution0/dotnet.csproj]\n"
+        f"{workdir}/Execution0/Submission.cs(16,9): warning CS0219: "
+        f"unused [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    _, annotations, _, _ = language_config.compiler_output(stdout, "")
+    assert [(a.row, a.type) for a in annotations] == [(2, "error"), (4, "warning")]
+
+
+def test_csharp_compiler_output_skips_wrapper_diagnostics():
+    workdir = "/home/bliep/bloep/universal-judge/workdir"
+    language_config = get_language(workdir, "csharp")
+    assert language_config.config
+    language_config.config.dodona.source_offset = -12
+    stdout = (
+        f"{workdir}/Execution0/Submission.cs(1,1): warning CS8019: "
+        f"Unnecessary using directive. [{workdir}/Execution0/dotnet.csproj]\n"
+        f"{workdir}/Execution0/Submission.cs(14,19): error CS0103: "
+        f"undefined [{workdir}/Execution0/dotnet.csproj]\n"
+    )
+    _, annotations, _, _ = language_config.compiler_output(stdout, "")
+    assert [(a.row, a.type) for a in annotations] == [(2, "error")]


### PR DESCRIPTION
Part of #596., and continues from #654 (which by itself continues from #653). The diff here is only the C# `compiler_output` change.

This PR resurrects the dead (🧟) compiler-error annotations that TESTed provides. They got lose since the regex that searches for them was looking for `Submission(...)`, while the compiler emits `Submission.cs(...)`, so the regex never matches.

But ... there's more: the annotation is added in every test case, and is never deduplicated:

<img width="1211" height="1047" alt="image" src="https://github.com/user-attachments/assets/a9319509-04f1-4fe5-87a0-3160dab00594" />

Fixing this is out of scope for this PR & ticket. I'll follow up on this in the next PR.

### Manual testing:
1. On main, submit a program with just `sup` in it
2. Assert the output comes back with a single compilation error, and 0 code annotations
3. Switch to this branch and re-evaluate
4. Assert that the output comes back with the same single compilation error, but also includes code annotations to the code tab

<details>

### What

`compiler_output`'s regex looked for `Submission(...)`, but the compiler emits `Submission.cs(...)`, so it never matched and C# compile-error annotations were silently never produced. This fixes the regex, applies the line offset (from #653) to the annotation row, and skips diagnostics that fall on the generated wrapper (they map to a non-positive row and are not part of the student's code).

### Tests

Adds the first tests for `compiler_output`: single annotation with the offset applied, multiple diagnostics, and wrapper-line skipping.

</details>