### PR TITLE
Deduplicate compile-error annotations across test cases

### DIFF
--- a/tested/judge/collector.py
+++ b/tested/judge/collector.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from typing import IO, Literal
 
 from tested.dodona import (
+    AnnotateCode,
     AppendMessage,
     CloseContext,
     CloseJudgement,
@@ -38,18 +39,21 @@ class OutputManager:
         "open_stack",
         "currently_open",
         "out",
+        "seen_annotations",
     ]
 
     finalized: bool
     open_stack: list[str]
     currently_open: tuple[int, int, int]
     out: IO
+    seen_annotations: list[AnnotateCode]
 
     def __init__(self, out: IO):
         self.finalized = False
         self.open_stack = []
         self.currently_open = (0, 0, 0)
         self.out = out
+        self.seen_annotations = []
 
     def add_all(self, commands: Iterable[Update]):
         for command in commands:
@@ -57,6 +61,22 @@ class OutputManager:
 
     def add_messages(self, messages: Iterable[Message]):
         self.add_all(AppendMessage(message=m) for m in messages)
+
+    def add_unique_annotations(self, annotations: Iterable[AnnotateCode]):
+        """
+        Add code annotations, skipping any identical to one already emitted.
+
+        A compile error marks the student's submission, so the same annotation
+        is produced for every failing test case. We still want a single marker
+        on the line, so drop the duplicates here. This is only used for compiler
+        annotations; linter annotations go through add_all and are never
+        de-duplicated, since a linter may legitimately repeat itself.
+        """
+        for annotation in annotations:
+            if annotation in self.seen_annotations:
+                continue
+            self.seen_annotations.append(annotation)
+            self.add(annotation)
 
     def add(self, command: Update, index: int | None = None):
         """

--- a/tested/judge/core.py
+++ b/tested/judge/core.py
@@ -149,15 +149,23 @@ def judge(bundle: Bundle):
         _handle_time_or_memory_compilation(bundle, collector, compilation_results)
         return
 
-    # If the compilation failed, but we can fall back, do that.
-    if (
-        compilation_results.status != Status.CORRECT
-        and bundle.config.options.allow_fallback
-    ):
-        _logger.warning("Precompilation failed. Falling back to unit compilation.")
-        planned_units = plan_test_suite(bundle, strategy=PlanStrategy.TAB)
-        plan.units = planned_units
-        compilation_results = None
+    if compilation_results.status != Status.CORRECT:
+        # The per-test-case compiler messages, code annotations and status are
+        # reported per context in evaluate_context_results. A compile error
+        # marks the student's submission, so the same annotation is emitted for
+        # every failing test case; the OutputManager deduplicates identical
+        # annotations so a single marker is shown on the line.
+
+        # Only fall back to per-unit compilation when the failure is not pinned
+        # to the submission. If precompilation produced code annotations, the
+        # submission itself failed to compile, so every per-unit recompile would
+        # re-hit the same error: the fallback is pointless (and for C# its shared
+        # selector cannot even compile per unit).
+        if bundle.config.options.allow_fallback and not compilation_results.annotations:
+            _logger.warning("Precompilation failed. Falling back to unit compilation.")
+            planned_units = plan_test_suite(bundle, strategy=PlanStrategy.TAB)
+            plan.units = planned_units
+            compilation_results = None
 
     _logger.info("Starting execution")
 

--- a/tested/judge/evaluation.py
+++ b/tested/judge/evaluation.py
@@ -191,13 +191,15 @@ def evaluate_context_results(
     if compilation_results.status != Status.CORRECT:
         readable_input = attempt_readable_input(bundle, context)
         collector.add(StartTestcase(description=readable_input))
-        # Report all compiler messages.
-        if not compilation_results.reported:
-            collector.add_messages(compilation_results.messages)
-            collector.add_all(compilation_results.annotations)
-            collector.add(
-                EscalateStatus(status=StatusMessage(enum=compilation_results.status))
-            )
+        # Report the compiler messages, annotations and status per test case.
+        # The same compile error annotation is emitted for every failing test
+        # case, so add_unique_annotations drops the duplicates and the student
+        # sees a single marker on the line.
+        collector.add_messages(compilation_results.messages)
+        collector.add_unique_annotations(compilation_results.annotations)
+        collector.add(
+            EscalateStatus(status=StatusMessage(enum=compilation_results.status))
+        )
 
         # Finish the evaluation, since there is nothing we can do.
         collector.add(CloseTestcase(accepted=False), 0)

--- a/tested/judge/planning.py
+++ b/tested/judge/planning.py
@@ -21,7 +21,6 @@ class CompilationResult:
     status: Status
     messages: list[Message] = field(factory=list)
     annotations: list[AnnotateCode] = field(factory=list)
-    reported: bool = False
 
 
 @define

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -400,7 +400,14 @@ def test_batch_compilation_fallback(
     updates = assert_valid_output(result, pytestconfig)
     assert len(updates.find_all("start-testcase")) == 2
     assert updates.find_status_enum() == ["compilation error"] * 2
-    assert spy.call_count == 3
+    # When precompilation pins the failure to the submission it produces code
+    # annotations, so the (pointless) per-unit fallback is skipped and compile
+    # runs once; otherwise the judge falls back and recompiles each unit
+    # (precompile + one per unit).
+    if updates.find_all("annotate-code"):
+        assert spy.call_count == 1
+    else:
+        assert spy.call_count == 3
 
 
 @pytest.mark.parametrize("language", ALL_LANGUAGES)
@@ -435,6 +442,40 @@ def test_batch_compilation_no_fallback_runtime(
     assert len(updates.find_status_enum()) >= 4
     # There could be more wrongs: some languages might modify the exit code
     assert all(s in ("runtime error", "wrong") for s in updates.find_status_enum())
+
+
+@pytest.mark.parametrize("language", ALL_LANGUAGES)
+def test_compile_error_annotations_emitted_once(
+    language: str, tmp_path: Path, pytestconfig: pytest.Config
+):
+    # A compilation error marks the student's code, so its annotations must be
+    # emitted once, not once per test case. A failing submission is split into
+    # one execution unit per stdin test case, each recompiled on the fallback
+    # path, so without the judgement-level emit the annotations would be
+    # duplicated per test case. Compiling the same broken submission with more
+    # test cases must not multiply the annotations, while the per-test-case
+    # status is still reported.
+    one_dir = tmp_path / "one"
+    one_dir.mkdir()
+    two_dir = tmp_path / "two"
+    two_dir.mkdir()
+    conf_one = configuration(
+        pytestconfig, "echo", language, one_dir, "one.tson", "comp-error"
+    )
+    one = assert_valid_output(execute_config(conf_one), pytestconfig)
+    conf_two = configuration(
+        pytestconfig, "echo", language, two_dir, "two.tson", "comp-error"
+    )
+    two = assert_valid_output(execute_config(conf_two), pytestconfig)
+
+    assert one.find_status_enum() == ["compilation error"]
+    assert two.find_status_enum() == ["compilation error"] * 2
+    # The annotation count must not scale with the number of test cases.
+    assert len(two.find_all("annotate-code")) == len(one.find_all("annotate-code"))
+    if language == "csharp":
+        # Guard that C# actually emits compile annotations (see #655), so this
+        # test genuinely exercises the de-duplication path.
+        assert len(two.find_all("annotate-code")) >= 1
 
 
 @pytest.mark.parametrize("lang", all_languages_except("haskell", "runhaskell"))


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

Part of #596. **Stacked on #655** (the annotations only appear once #655 resurrects them); retarget to its base once that merges.

### What

A failing submission is split into one execution unit per stdin test case (`has_stdin_conflict` in `planning.py`), so every failing context reports the *same* compile-error annotation. The per-result `reported` flag (never set to `True` anyway) couldn't dedup across those results, so the identical inline annotation showed up once per test case (e.g. 8 copies stacked on one line for an 8-test-case exercise).

The `OutputManager` now remembers the annotations it has already emitted and skips the identical ones. `evaluate_context_results` still reports the compiler messages, annotations and status per test case, but `add_unique_annotations` drops an annotation identical to one already shown, so the student sees a single marker on the line. The per-test-case *messages* and status are unchanged (you still get one "compilation error" per test case). The dead `reported` flag is dropped.

The dedup is scoped to compiler annotations: linter annotations keep going through `add_all` and are never touched, since a linter can legitimately flag the same-looking issue more than once (shellcheck does, for one). Only C# emits compile annotations today, so in practice this only changes the C# path.

It also **skips the per-unit fallback when precompilation produced annotations**. A non-empty annotation set means the submission itself failed to compile, so every per-unit recompile would just re-hit the same error: the fallback is pointless, and for C# it can't even compile per unit anyway (its shared `Selector.cs` references execution units absent from each per-unit dir). Every other language still falls back exactly as before.

### Tests

- `test_compile_error_annotations_emitted_once`: compiling the same failing submission with more test cases must not multiply the annotations, while the per-test-case status is still reported. Fails on the base (twice the annotations for two test cases), passes here.
- `test_batch_compilation_fallback` ties the compile-call count to whether annotations were emitted (annotations means the fallback is skipped, so one compile; otherwise precompile plus one per unit).

### Manual testing

A class-less C# submission that doesn't compile, with several stdin/stdout test cases. Before: one identical annotation per test case. After: a single `annotate-code`, one `compilation error` status per test case, and no wasted per-unit recompiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
