### PR TITLE
Fix per-unit fallback compilation for selector languages

### DIFF
--- a/tested/judge/core.py
+++ b/tested/judge/core.py
@@ -39,7 +39,12 @@ from tested.judge.planning import (
     plan_test_suite,
 )
 from tested.judge.utils import copy_from_paths_to_path
-from tested.languages.conventionalize import submission_file
+from tested.languages.conventionalize import (
+    EXECUTION_PREFIX,
+    conventionalize_namespace,
+    selector_file,
+    submission_file,
+)
 from tested.languages.generation import (
     generate_execution,
     generate_selector,
@@ -164,7 +169,22 @@ def judge(bundle: Bundle):
         if bundle.config.options.allow_fallback and not compilation_results.annotations:
             _logger.warning("Precompilation failed. Falling back to unit compilation.")
             planned_units = plan_test_suite(bundle, strategy=PlanStrategy.TAB)
+            # The execution files (and selector) were generated for the merged
+            # precompilation plan, so they no longer match the re-planned units.
+            # Regenerate them for the TAB units, with a selector over exactly
+            # those units. The submission itself is left untouched: it was copied
+            # and modify_solution'ed once, and re-modifying it would corrupt the
+            # source offset.
+            _clear_generated_execution_files(bundle, plan.common_directory)
+            dependencies = bundle.language.initial_dependencies()
+            dependencies.append(submission_file(bundle.language))
+            generated, selector = _generate_execution_files(
+                bundle, planned_units, plan.common_directory
+            )
+            dependencies.extend(generated)
             plan.units = planned_units
+            plan.files = dependencies
+            plan.selector = selector
             compilation_results = None
 
     _logger.info("Starting execution")
@@ -256,6 +276,68 @@ def _execute_one_unit(
     return local_compilation_results, execution_result, execution_dir
 
 
+def _generate_execution_files(
+    bundle: Bundle,
+    units: list[PlannedExecutionUnit],
+    destination: Path,
+) -> tuple[list[str], str | None]:
+    """
+    Generate the execution harness file for every unit (plus its oracle files)
+    into ``destination``, and a selector over exactly those units when the
+    language needs one.
+
+    This deliberately does not touch the submission file or the initial
+    dependencies: the caller owns those. It is shared by the initial generation
+    and by the per-unit fallback, which re-plans the units and so needs fresh,
+    matching execution files and a selector that names only the new units.
+
+    :return: A tuple of the generated dependency names and the selector name (or
+             ``None`` when the language does not need one). The selector is last,
+             which some languages rely on to pick the entry point.
+    """
+    dependencies: list[str] = []
+    execution_names: list[str] = []
+    for execution_unit in units:
+        _logger.debug("Generating file for execution %s", execution_unit.name)
+        generated, evaluators = generate_execution(
+            bundle=bundle, destination=destination, execution_unit=execution_unit
+        )
+
+        # Copy oracle functions to the directory.
+        for evaluator in evaluators:
+            source = Path(bundle.config.resources) / evaluator
+            _logger.debug("Copying oracle from %s to %s", source, destination)
+            shutil.copy2(source, destination)
+
+        dependencies.extend(evaluators)
+        dependencies.append(generated)
+        execution_names.append(execution_unit.name)
+
+    selector = None
+    if bundle.language.needs_selector():
+        _logger.debug("Generating selector.")
+        selector = generate_selector(bundle, destination, execution_names)
+        dependencies.append(selector)
+    return dependencies, selector
+
+
+def _clear_generated_execution_files(bundle: Bundle, common_dir: Path) -> None:
+    """
+    Remove the previously generated execution files (and the selector) from the
+    common directory, so the fallback can regenerate them for the re-planned
+    units without leaving stale files behind. The submission, dependencies and
+    oracle files are left in place: only execution-prefixed files and the
+    selector are removed.
+    """
+    prefix = conventionalize_namespace(bundle.language, EXECUTION_PREFIX)
+    selector = (
+        selector_file(bundle.language) if bundle.language.needs_selector() else None
+    )
+    for file in common_dir.iterdir():
+        if file.is_file() and (file.name.startswith(prefix) or file.name == selector):
+            file.unlink()
+
+
 def _generate_files(
     bundle: Bundle, execution_plan: list[PlannedExecutionUnit]
 ) -> tuple[Path, list[str], str | None]:
@@ -282,32 +364,10 @@ def _generate_files(
     # Allow modifications of the submission file.
     bundle.language.modify_solution(solution_path)
 
-    # The names of the executions for the test suite.
-    execution_names = []
-    # Generate the files for each execution.
-    for execution_unit in execution_plan:
-        _logger.debug("Generating file for execution %s", execution_unit.name)
-        generated, evaluators = generate_execution(
-            bundle=bundle, destination=common_dir, execution_unit=execution_unit
-        )
-
-        # Copy functions to the directory.
-        for evaluator in evaluators:
-            source = Path(bundle.config.resources) / evaluator
-            _logger.debug("Copying oracle from %s to %s", source, common_dir)
-            shutil.copy2(source, common_dir)
-
-        dependencies.extend(evaluators)
-        dependencies.append(generated)
-        execution_names.append(execution_unit.name)
-
-    if bundle.language.needs_selector():
-        _logger.debug("Generating selector.")
-        generated = generate_selector(bundle, common_dir, execution_names)
-        dependencies.append(generated)
-    else:
-        generated = None
-    return common_dir, dependencies, generated
+    # Generate the execution files and (if needed) the selector.
+    generated, selector = _generate_execution_files(bundle, execution_plan, common_dir)
+    dependencies.extend(generated)
+    return common_dir, dependencies, selector
 
 
 def _process_results(

--- a/tested/judge/core.py
+++ b/tested/judge/core.py
@@ -296,6 +296,7 @@ def _generate_execution_files(
              which some languages rely on to pick the entry point.
     """
     dependencies: list[str] = []
+    seen: set[str] = set()
     execution_names: list[str] = []
     for execution_unit in units:
         _logger.debug("Generating file for execution %s", execution_unit.name)
@@ -303,13 +304,19 @@ def _generate_execution_files(
             bundle=bundle, destination=destination, execution_unit=execution_unit
         )
 
-        # Copy oracle functions to the directory.
+        # Copy oracle functions to the directory. A language-specific oracle has
+        # the same filename for every unit that uses it, so copy and list each
+        # only once: otherwise a duplicate ends up in plan.files and the per-unit
+        # hardlinking would clash.
         for evaluator in evaluators:
+            if evaluator in seen:
+                continue
+            seen.add(evaluator)
             source = Path(bundle.config.resources) / evaluator
             _logger.debug("Copying oracle from %s to %s", source, destination)
             shutil.copy2(source, destination)
+            dependencies.append(evaluator)
 
-        dependencies.extend(evaluators)
         dependencies.append(generated)
         execution_names.append(execution_unit.name)
 

--- a/tested/judge/execution.py
+++ b/tested/judge/execution.py
@@ -175,8 +175,10 @@ def set_up_unit(
         destination = execution_dir / file
         destination.parent.mkdir(parents=True, exist_ok=True)
         _logger.debug("Copying %s to %s", origin, destination)
-        if origin == destination:
-            continue  # Don't copy the file to itself
+        if origin == destination or destination.exists():
+            # Don't copy the file to itself, and don't clash if a dependency is
+            # listed more than once (e.g. an oracle shared across units).
+            continue
 
         # Use hard links instead of copying, due to issues with busy files.
         # See https://github.com/dodona-edu/universal-judge/issues/57

--- a/tested/judge/execution.py
+++ b/tested/judge/execution.py
@@ -15,7 +15,8 @@ from tested.judge.utils import (
     filter_files,
     run_command,
 )
-from tested.languages.conventionalize import selector_name
+from tested.languages.conventionalize import selector_file, selector_name
+from tested.languages.generation import generate_selector
 from tested.languages.preparation import exception_file, value_file
 from tested.testsuite import ContentPath
 from tested.utils import safe_del
@@ -215,6 +216,17 @@ def compile_unit(
     dependencies: list[Path],
 ) -> tuple[CompilationResult, list[Path]]:
     unit = plan.units[which_unit]
+    if bundle.language.needs_selector():
+        # We fell back to per-unit compilation. set_up_unit hardlinked the shared
+        # all-units selector into this directory, but it still references the
+        # sibling execution files that filter_dependencies dropped, so it would
+        # dangle (a CS0103 / "no such module" for symbol-based selectors). Drop
+        # the hardlink and regenerate a selector that names only this unit. The
+        # unlink is load-bearing: writing through the hardlink would mutate the
+        # shared selector in common/ and in every sibling unit directory.
+        selector_path = execution_dir / selector_file(bundle.language)
+        selector_path.unlink(missing_ok=True)
+        generate_selector(bundle, execution_dir, [unit.name])
     _logger.info(f"Compiling unit {unit.name}")
     remaining = plan.remaining_time()
     deps = [str(x) for x in dependencies]

--- a/tests/exercises/partial-function/evaluation/Evaluator.cs
+++ b/tests/exercises/partial-function/evaluation/Evaluator.cs
@@ -1,0 +1,11 @@
+using Tested;
+using System.Collections.Generic;
+
+public class Evaluator
+{
+    public static EvaluationResult Evaluate(object actual)
+    {
+        string shown = actual != null ? actual.ToString() : "";
+        return new EvaluationResult(true, shown, shown, new List<Message>());
+    }
+}

--- a/tests/exercises/partial-function/evaluation/shared-oracle.yaml
+++ b/tests/exercises/partial-function/evaluation/shared-oracle.yaml
@@ -1,0 +1,20 @@
+- tab: "triple"
+  contexts:
+    - testcases:
+        - expression: "triple(2)"
+          return: !oracle
+            oracle: specific_check
+            functions:
+              csharp:
+                file: Evaluator.cs
+                name: evaluate
+- tab: "quadruple"
+  contexts:
+    - testcases:
+        - expression: "quadruple(2)"
+          return: !oracle
+            oracle: specific_check
+            functions:
+              csharp:
+                file: Evaluator.cs
+                name: evaluate

--- a/tests/exercises/partial-function/evaluation/two-functions.yaml
+++ b/tests/exercises/partial-function/evaluation/two-functions.yaml
@@ -1,0 +1,10 @@
+- tab: "triple"
+  contexts:
+    - testcases:
+        - expression: "triple(2)"
+          return: 6
+- tab: "quadruple"
+  contexts:
+    - testcases:
+        - expression: "quadruple(2)"
+          return: 8

--- a/tests/exercises/partial-function/solution/correct.c
+++ b/tests/exercises/partial-function/solution/correct.c
@@ -1,0 +1,7 @@
+int triple(int x) {
+    return 3 * x;
+}
+
+int quadruple(int x) {
+    return 4 * x;
+}

--- a/tests/exercises/partial-function/solution/correct.cpp
+++ b/tests/exercises/partial-function/solution/correct.cpp
@@ -1,0 +1,7 @@
+int triple(int x) {
+    return 3 * x;
+}
+
+int quadruple(int x) {
+    return 4 * x;
+}

--- a/tests/exercises/partial-function/solution/correct.cs
+++ b/tests/exercises/partial-function/solution/correct.cs
@@ -1,0 +1,12 @@
+class Submission
+{
+    public static int Triple(int x)
+    {
+        return 3 * x;
+    }
+
+    public static int Quadruple(int x)
+    {
+        return 4 * x;
+    }
+}

--- a/tests/exercises/partial-function/solution/correct.hs
+++ b/tests/exercises/partial-function/solution/correct.hs
@@ -1,0 +1,5 @@
+triple :: Int -> Int
+triple x = 3 * x
+
+quadruple :: Int -> Int
+quadruple x = 4 * x

--- a/tests/exercises/partial-function/solution/correct.java
+++ b/tests/exercises/partial-function/solution/correct.java
@@ -1,0 +1,10 @@
+class Submission {
+
+    public static int triple(int x) {
+        return 3 * x;
+    }
+
+    public static int quadruple(int x) {
+        return 4 * x;
+    }
+}

--- a/tests/exercises/partial-function/solution/correct.kt
+++ b/tests/exercises/partial-function/solution/correct.kt
@@ -1,0 +1,7 @@
+fun triple(x: Int): Int {
+    return 3 * x
+}
+
+fun quadruple(x: Int): Int {
+    return 4 * x
+}

--- a/tests/exercises/partial-function/solution/partial.c
+++ b/tests/exercises/partial-function/solution/partial.c
@@ -1,0 +1,3 @@
+int triple(int x) {
+    return 3 * x;
+}

--- a/tests/exercises/partial-function/solution/partial.cpp
+++ b/tests/exercises/partial-function/solution/partial.cpp
@@ -1,0 +1,3 @@
+int triple(int x) {
+    return 3 * x;
+}

--- a/tests/exercises/partial-function/solution/partial.cs
+++ b/tests/exercises/partial-function/solution/partial.cs
@@ -1,0 +1,7 @@
+class Submission
+{
+    public static int Triple(int x)
+    {
+        return 3 * x;
+    }
+}

--- a/tests/exercises/partial-function/solution/partial.hs
+++ b/tests/exercises/partial-function/solution/partial.hs
@@ -1,0 +1,2 @@
+triple :: Int -> Int
+triple x = 3 * x

--- a/tests/exercises/partial-function/solution/partial.java
+++ b/tests/exercises/partial-function/solution/partial.java
@@ -1,0 +1,6 @@
+class Submission {
+
+    public static int triple(int x) {
+        return 3 * x;
+    }
+}

--- a/tests/exercises/partial-function/solution/partial.kt
+++ b/tests/exercises/partial-function/solution/partial.kt
@@ -1,0 +1,3 @@
+fun triple(x: Int): Int {
+    return 3 * x
+}

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -478,6 +478,62 @@ def test_compile_error_annotations_emitted_once(
         assert len(two.find_all("annotate-code")) >= 1
 
 
+# The compiled languages that need a selector; only these reach the per-unit
+# fallback compilation that regenerates the execution files and selector.
+SELECTOR_LANGUAGES = ["c", "cpp", "csharp", "haskell", "java", "kotlin"]
+
+
+@pytest.mark.parametrize("language", SELECTOR_LANGUAGES)
+def test_partial_compilation_fallback(
+    language: str, tmp_path: Path, pytestconfig: pytest.Config, mocker: MockerFixture
+):
+    # A partial solution: only `triple` is implemented, not `quadruple`. The two
+    # tabs are function tests, so precompilation merges them into one unit whose
+    # harness calls the missing `quadruple` and fails to compile. The fallback
+    # must then recompile each tab on its own, so the `triple` tab compiles and
+    # passes while only the `quadruple` tab reports a compilation error.
+    lang_class = LANGUAGES[language]
+    spy = mocker.spy(lang_class, "compilation")
+    conf = configuration(
+        pytestconfig,
+        "partial-function",
+        language,
+        tmp_path,
+        "two-functions.yaml",
+        "partial",
+        {"options": {"allow_fallback": True}},
+    )
+    updates = assert_valid_output(execute_config(conf), pytestconfig)
+    assert len(updates.find_all("start-tab")) == 2
+    assert updates.find_status_enum() == ["correct", "compilation error"]
+    # The error is in the generated harness, not the submission, so it must not
+    # pin a code annotation to the submission, or the judgement-level annotation
+    # guard would skip the fallback and both tabs would fail to compile.
+    assert updates.find_all("annotate-code") == []
+    assert spy.call_count == 3  # precompile + one recompile per TAB unit
+
+
+@pytest.mark.parametrize("language", SELECTOR_LANGUAGES)
+def test_partial_compilation_full_solution(
+    language: str, tmp_path: Path, pytestconfig: pytest.Config, mocker: MockerFixture
+):
+    # Control: the complete solution precompiles in one go, no fallback.
+    lang_class = LANGUAGES[language]
+    spy = mocker.spy(lang_class, "compilation")
+    conf = configuration(
+        pytestconfig,
+        "partial-function",
+        language,
+        tmp_path,
+        "two-functions.yaml",
+        "correct",
+        {"options": {"allow_fallback": True}},
+    )
+    updates = assert_valid_output(execute_config(conf), pytestconfig)
+    assert updates.find_status_enum() == ["correct", "correct"]
+    assert spy.call_count == 1
+
+
 @pytest.mark.parametrize("lang", all_languages_except("haskell", "runhaskell"))
 def test_program_params(lang: str, tmp_path: Path, pytestconfig: pytest.Config):
     conf = configuration(pytestconfig, "sum", lang, tmp_path, "short.tson", "correct")

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -534,6 +534,26 @@ def test_partial_compilation_full_solution(
     assert spy.call_count == 1
 
 
+def test_partial_compilation_fallback_shared_oracle(
+    tmp_path: Path, pytestconfig: pytest.Config
+):
+    # Both tabs use the same language-specific oracle (Evaluator.cs). When the
+    # partial submission forces the fallback, that oracle must be regenerated and
+    # hardlinked once per unit, not once per tab, or set_up_unit raises
+    # FileExistsError and the judgement crashes instead of giving partial credit.
+    conf = configuration(
+        pytestconfig,
+        "partial-function",
+        "csharp",
+        tmp_path,
+        "shared-oracle.yaml",
+        "partial",
+        {"options": {"allow_fallback": True}},
+    )
+    updates = assert_valid_output(execute_config(conf), pytestconfig)
+    assert updates.find_status_enum() == ["correct", "compilation error"]
+
+
 @pytest.mark.parametrize("lang", all_languages_except("haskell", "runhaskell"))
 def test_program_params(lang: str, tmp_path: Path, pytestconfig: pytest.Config):
     conf = configuration(pytestconfig, "sum", lang, tmp_path, "short.tson", "correct")


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

Fixes the precompile→fallback path for the selector languages (#657). When precompilation of the merged plan fails, the judge re-plans per-tab and recompiles each unit on its own. That fallback was quietly broken for everything that needs a selector (c, cpp, csharp, haskell, java, kotlin), so a submission that compiles some tabs but not others lost all partial credit instead of getting credit for the tabs that do compile. Two regressions from #437 "Rework execution", both traced in #657:

1. **Dangling selector.** The all-units selector got hardlinked into every per-unit dir, but `filter_dependencies` drops the sibling execution files, so it referenced units that aren't there (CS0103 / "no such module"). C++ got away with it because its selector guards the includes with `#if __has_include`.
2. **Stale execution files.** The fallback re-planned to TAB units but kept reusing the execution files generated for the merged plan. For function/expression exercises OPTIMAL merges everything into a single `Execution0`, so the per-tab units pointed at files that were never generated.

### What changed

- `core.py`: extracted the execution-file generation into a shared `_generate_execution_files` helper and call it again in the fallback, after clearing the stale files, so the TAB units get fresh files and a selector that names exactly those units. The submission is deliberately left alone: it was copied and `modify_solution`'ed once already, and re-modifying it would corrupt the source offset from #653.
- `execution.py`: `compile_unit` drops the hardlinked all-units selector and regenerates a single-unit one before compiling. It's self-gated on the fallback (only runs when `compilation_results is None`).
- A language-specific oracle shared across units keeps the same filename per unit, so it's now copied and listed once, and `set_up_unit` skips a dependency that's already linked. Without that a shared `Evaluator.cs` ended up in `plan.files` twice and the second hardlink raised `FileExistsError`. (Found in review.)

I left the orphaned `ExecutionMode` enum and `Options.mode` alone (also dead since #437), feels like a separate cleanup.

### Testing

New `partial-function` exercise (two tabs, one function each) with a `correct` and a `partial` solution per compiled language:

- `test_partial_compilation_fallback` over the six selector languages: partial solution → `["correct", "compilation error"]`, no `annotate-code`, 3 compiles (precompile + one per TAB unit).
- `test_partial_compilation_full_solution`: correct solution → `["correct", "correct"]`, 1 compile (no fallback).
- `test_partial_compilation_fallback_shared_oracle` (csharp): same partial result with one `!oracle` shared across both tabs, guarding the dedup fix.

<details>
<summary>Run them against the real judge</summary>

```
docker run --rm --platform linux/amd64 \
  -v <worktree>:/judge -w /judge --entrypoint bash \
  ghcr.io/dodona-edu/dodona-tested \
  -lc 'pip install --user pytest pytest-mock pytest-xdist syrupy && python3 -m pytest tests/test_functionality.py -k partial_compilation'
```
</details>

Stacked on #656.

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
