### PR TITLE
Add wget to the TESTed image

### DIFF
--- a/.devcontainer/dodona-tested.dockerfile
+++ b/.devcontainer/dodona-tested.dockerfile
@@ -41,6 +41,7 @@ CFG
         procps \
         dos2unix \
         curl \
+        wget \
         zip \
         unzip
 


### PR DESCRIPTION
Adds `wget` to the general dependencies of the TESTed image so exercises can use it.

Requested in dodona-edu/dodona#7229 (cross-repo, so it won't auto-close; close it once this is deployed).

| | Uncompressed (on disk) | Compressed (pull) |
|---|---|---|
| before | 6.95 GB | 1.91 GB |
| increase | **+1.56 MB** | **+0.46 MB** |

So ~0.02% on a 6.95 GB image.

<details>

`wget` pulls in no new transitive packages, its dependencies are already present in the base image, so the footprint increase is tiny.

## Image size impact

Measured by layering only this change on top of the published `dodona/dodona-tested:latest` (amd64, digest `sha256:34f3c447…`, built 2025-08-19) and comparing image sizes. Both columns are reported because they answer different questions: on-disk is the runtime footprint, compressed is the registry/pull cost.

| | Uncompressed (on disk) | Compressed (pull) |
|---|---|---|
| before | 6.95 GB | 1.91 GB |
| increase | **+1.56 MB** | **+0.46 MB** |


## How to verify

CI builds the image from this Dockerfile. For a quick local check without a full rebuild, layer the change on the published image:

```sh
docker build --platform linux/amd64 -t tested-wget - <<'EOF'
FROM dodona/dodona-tested:latest
USER root
RUN apt-get update && apt-get install -y --no-install-recommends wget \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
USER runner
EOF
docker run --rm --platform linux/amd64 tested-wget wget --version | head -1
# -> GNU Wget 1.21 built on linux-gnu.
```

</details>
