### PR TITLE
Add lxml to the TESTed image

### DIFF
--- a/.devcontainer/dodona-tested.dockerfile
+++ b/.devcontainer/dodona-tested.dockerfile
@@ -127,7 +127,8 @@ CFG
       numpy==2.4.6 \
       pandas==3.0.3 \
       openpyxl==3.1.5 \
-      matplotlib==3.10.9
+      matplotlib==3.10.9 \
+      lxml==6.1.1
 
     # Clean up caches
     apt-get clean


### PR DESCRIPTION
Adds the `lxml` Python module (pinned to `lxml==6.1.1`) to the exercise dependencies of the TESTed image so exercises can use it.

Requested in dodona-edu/dodona#5999 (cross-repo, so it won't auto-close; close it once this is deployed).

| | Uncompressed (on disk) | Compressed (pull) |
|---|---|---|
| before | 6.95 GB | 1.91 GB |
| increase | **+12.7 MB** | **+5.44 MB** |

So ~0.18% on a 6.95 GB image.

<details>

`lxml` ships manylinux wheels with libxml2/libxslt bundled, so there's no compilation and no extra apt/pip dependencies pulled in.

## Image size impact

Measured by layering only this change on top of the published `dodona/dodona-tested:latest` (amd64, digest `sha256:34f3c447…`, built 2025-08-19) and comparing image sizes. Both columns are reported because they answer different questions: on-disk is the runtime footprint, compressed is the registry/pull cost.

| | Uncompressed (on disk) | Compressed (pull) |
|---|---|---|
| before | 6.95 GB | 1.91 GB |
| increase | **+12.7 MB** | **+5.44 MB** |

So ~0.18% on a 6.95 GB image.

## How to verify

CI builds the image from this Dockerfile. For a quick local check without a full rebuild, layer the change on the published image:

```sh
docker build --platform linux/amd64 -t tested-lxml - <<'EOF'
FROM dodona/dodona-tested:latest
USER root
RUN pip install --no-cache-dir --upgrade lxml==6.1.1
USER runner
EOF
docker run --rm --platform linux/amd64 tested-lxml python -c "import lxml.etree; print(lxml.etree.__version__)"
# -> 6.1.1
```

</details>