### PR TITLE
Install git via apt in the devcontainer instead of from source

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,6 @@
   },
   "postCreateCommand": "./.devcontainer/dev-dependencies.sh",
   "features" : {
-    // add git to the container
-    "ghcr.io/devcontainers/features/git:1": {
-      "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/git:1": {}
   }
 }


### PR DESCRIPTION
[I started hitting CI failures on actions here](https://github.com/dodona-edu/universal-judge/actions/runs/28359357093) when building the dev container since we built git from source in the devcontainer extension, rather than just using apt. This PR changes the git feature default to "os-provided" (which uses Apt on debian) from building it from source (from github, which hit those rate limits).

<details>


The `git` devcontainer feature was pinned to `"version": "latest"`, which builds git **from source**. That source build resolves the latest release through the GitHub REST API *unauthenticated*, and since GitHub-hosted runners share a NAT IP per region they collectively burn through the 60 req/hour unauthenticated limit. When it's exhausted the feature install dies with `API rate limit exceeded` and the whole devcontainer build fails ([example run](https://github.com/dodona-edu/universal-judge/actions/runs/28359357093)).

Dropping the explicit version falls back to the feature's default, `os-provided`, which installs Debian's git via `apt` and never touches the GitHub API. Git stays available in the container (handy for in-container dev); we just stop building it from source. `latest` wasn't a deliberate choice anyway, it came in as the feature-template default via #556.

### Testing
- The `build_devcontainer` job installs git via `apt` instead of the from-source path, so the unauthenticated API call (and that whole class of rate-limit failure) is gone. CI on this branch exercises it.

</details>