### PR TITLE
Bump GitHub Actions off Node 20 and add weekly Actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "13:00"
+    timezone: Europe/Brussels
+  open-pull-requests-limit: 99

--- a/.github/workflows/build_devcontainer.yml
+++ b/.github/workflows/build_devcontainer.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
       - name: Checkout (GitHub)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     needs: [build_devcontainer]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -29,7 +29,7 @@ jobs:
           push: never
           runCmd: pytest -n auto --cov=tested --cov-report=xml tests/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./result/coverage.xml
@@ -37,7 +37,7 @@ jobs:
     needs: [build_devcontainer]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -59,7 +59,7 @@ jobs:
     needs: [build_devcontainer]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -75,7 +75,7 @@ jobs:
     needs: [build_devcontainer]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -92,7 +92,7 @@ jobs:
     needs: [build_devcontainer]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Generate a token for dodona-edu/docker-images
         id: app-token
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
This PR:
- Bumps all action versions to latest (to be Node 24 compatible)
- Adds a dependabot action to bump all action versions

## Manual testing

This pipeline 😄 

<details>

GitHub now defaults workflows to Node 24 and warns on any action still declaring a `node16`/`node20` runtime ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The `build_devcontainer` job was the one tripping the warning, but a couple of other pins were on node20 too. I bumped each to its latest node24 major, and added a weekly `github-actions` dependabot entry so they stay current going forward.

### Action bumps
- `actions/checkout` v3/v4 → v7 (all workflows; v3 was node16, v4 node20)
- `docker/login-action` v2 → v4 (v2 node16, v3 still node20, v4 node24)
- `codecov/codecov-action` v4 → v7 (v4 node20; v5+ is a composite action)

Left as-is, already node24: `devcontainers/ci@v0.3`, `actions/create-github-app-token@v3`, `github/codeql-action@v4`, and `codeql.yml`'s `actions/checkout@v6` (the new dependabot will carry that one to v7).

### Dependabot
Added a `github-actions` ecosystem entry, weekly, matching the existing schedule style (13:00 Europe/Brussels, limit 99).

### Verification
- Checked the `using:` runtime in each external action's `action.yml`: every referenced version now resolves to `node24`.
- `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses clean.

</details>